### PR TITLE
Fix memory leak with routes queries

### DIFF
--- a/src/pycall.c
+++ b/src/pycall.c
@@ -31,7 +31,8 @@ char *pycall(PgSocket *client, char *username, char *query_str, char *py_file,
 	strcpy(py_pathtmp, py_file);
 	py_path = malloc(strlen(py_file) + 20) ;
         sprintf(py_path,"PYTHONPATH=%s",dirname(py_pathtmp)) ;
-	putenv(py_path) ; 
+	putenv(py_path) ;
+	free(py_path);
 
 	/* setup python module name, function name */
 	py_filetmp = malloc(strlen(py_file) + 1);

--- a/src/pycall.c
+++ b/src/pycall.c
@@ -32,7 +32,6 @@ char *pycall(PgSocket *client, char *username, char *query_str, char *py_file,
 	py_path = malloc(strlen(py_file) + 20) ;
         sprintf(py_path,"PYTHONPATH=%s",dirname(py_pathtmp)) ;
 	putenv(py_path) ;
-	free(py_path);
 
 	/* setup python module name, function name */
 	py_filetmp = malloc(strlen(py_file) + 1);
@@ -99,6 +98,7 @@ char *pycall(PgSocket *client, char *username, char *query_str, char *py_file,
 	}
 	free(py_pathtmp);
 	free(py_filetmp);
+	free(py_path);
 	Py_XDECREF(pName);
 	Py_XDECREF(pModule);
 	Py_XDECREF(pFunc);

--- a/src/route_connection.c
+++ b/src/route_connection.c
@@ -70,6 +70,7 @@ bool route_client_connection(PgSocket *client, PktHdr *pkt) {
 			"routing_rules");
 	if (dbname == NULL) {
 		slog_debug(client, "routing_rules returned 'None' - existing connection preserved");
+		free(dbname);
 		return false;
 	}
 
@@ -79,6 +80,7 @@ bool route_client_connection(PgSocket *client, PktHdr *pkt) {
 				"nonexistant database key <%s> returned by routing_rules",
 				dbname);
 		slog_error(client, "check ini and/or routing rules function");
+		free(dbname);
 		return false;
 	}
 	pool = get_pool(db, client->auth_user);
@@ -97,6 +99,7 @@ bool route_client_connection(PgSocket *client, PktHdr *pkt) {
 	} else {
 		slog_debug(client, "already connected to pool <%s>", dbname);
 	}
+	free(dbname);
 	return true;
 }
 


### PR DESCRIPTION
I noticed that Pgbouncer-rr was infinitely growing in memory usage in a production environment when utilising the query routing feature:

![Memory leak](https://s3.amazonaws.com/f.cl.ly/items/242R2P2F1q0H2X0U3u02/Image%202016-07-26%20at%209.55.46%20am.png?v=3523eb8d)

I've tracked it down to two `malloc` calls in pycall.c not being freed after use. This PR adds corresponding `frees` for each `malloc` call and is currently working nicely in production.
