### PR TITLE
client.c.diff: fix patch failure

### DIFF
--- a/src/client.c.diff
+++ b/src/client.c.diff
@@ -1,9 +1,8 @@
---- ../pgbouncer/src/client.c	2016-02-25 17:40:13.535332888 -0500
-+++ ./src/client.c	2016-02-25 17:39:16.065977034 -0500
-@@ -423,16 +423,16 @@ static bool decide_startup_pool(PgSocket
- 		} else if (strcmp(key, "user") == 0) {
- 			slog_debug(client, "got var: %s=%s", key, val);
- 			username = val;
+diff --git a/src/client.c b/src/client.c
+index 2a46e0d..4363736 100644
+--- a/src/client.c
++++ b/src/client.c
+@@ -446,10 +446,10 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
  		} else if (strcmp(key, "application_name") == 0) {
  			set_appname(client, val);
  			appname_found = true;
@@ -15,14 +14,8 @@
 +			slog_debug(client, "got var: %s=%s", key, val);
  		} else {
  			slog_warning(client, "unsupported startup parameter: %s=%s", key, val);
- 			disconnect_client(client, true, "Unsupported startup parameter: %s", key);
- 			return false;
- 		}
- 	}
-@@ -632,12 +632,20 @@ static bool handle_client_work(PgSocket
- 		client->query_start = get_cached_time();
- 	}
- 
+ 			disconnect_client(client, true, "unsupported startup parameter: %s", key);
+@@ -678,6 +678,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  	if (client->pool->db->admin)
  		return admin_handle_client(client, pkt);
  
@@ -37,6 +30,3 @@
  	/* acquire server */
  	if (!find_server(client))
  		return false;
- 
- 	/* postpone rfq change until certain that client will not be paused */
- 	if (rfq_delta) {


### PR DESCRIPTION
Regenerate the patch for client.c to apply to pgbouncer after commit:

https://github.com/pgbouncer/pgbouncer/commit/a0e1f696b94f91d79a1a45c72633c2c4f842fc8d.

~~~
Merging pgbouncer-rr changes to: ../pgbouncer/src/client.c
patching file src/client.c
Hunk #1 FAILED at 423.
Hunk #2 succeeded at 675 with fuzz 1 (offset 43 lines).
1 out of 2 hunks FAILED -- saving rejects to file src/client.c.rej
~~~