### PR TITLE
fixed pgbouncer-rr patch

### DIFF
--- a/main.c.diff
+++ b/main.c.diff
@@ -1,0 +1,27 @@
+--- ../pgbouncer/src/main.c 2020-04-26 15:20:51.662323314 -0400
++++ ./src/main.c    2020-04-26 15:19:21.995853494 -0400
+@@ -160,6 +160,11 @@
+ int cf_log_pooler_errors;
+ int cf_application_name_add_host;
+
++/* pgbouncer-rr  extension */
++char *cf_routing_rules_py_module_file;
++char *cf_rewrite_query_py_module_file;
++char *cf_rewrite_query_disconnect_on_failure;
++
+ int cf_client_tls_sslmode;
+ char *cf_client_tls_protocols;
+ char *cf_client_tls_ca_file;
+@@ -263,6 +263,11 @@
+ CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
+ CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
+ 
++/* pgbouncer-rr extensions */
++CF_ABS("routing_rules_py_module_file", CF_STR, cf_routing_rules_py_module_file, 0, "not_enabled"),
++CF_ABS("rewrite_query_py_module_file", CF_STR, cf_rewrite_query_py_module_file, 0, "not_enabled"),
++CF_ABS("rewrite_query_disconnect_on_failure", CF_STR, cf_rewrite_query_disconnect_on_failure, 0, "false"),
++
+ CF_ABS("max_packet_size", CF_UINT, cf_max_packet_size, 0, "2147483647"),
+ CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
+ CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
+


### PR DESCRIPTION
*Issue #, if available:*
solved pgbouncer-rr patch install fails with pgbouncer release v1.11.0 #42 

*Description of changes:*
changed the main.c.diff file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
