### PR TITLE
support python3.9 with amazonlinux:2022

### DIFF
--- a/Makefile.diff
+++ b/Makefile.diff
@@ -38,7 +38,7 @@
  	include/common/unicode_norm_table.h
  
 -pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS)
-+python_CPPFLAGS = -I/usr/include/python3.8 -I/usr/include/python3.8
++python_CPPFLAGS = -I/usr/include/python3.9 -I/usr/include/python3.9
 +pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS) $(python_CPPFLAGS)
  
  # include libusual sources directly
@@ -68,7 +68,7 @@
  		lib/README lib/COPYRIGHT \
  		lib/find_modules.sh )))
  
-+python_LDFLAGS = -lpthread -ldl -lutil -lm -lpython3.8 -Xlinker -export-dynamic
++python_LDFLAGS = -lpthread -ldl -lutil -lm -lpython3.9 -Xlinker -export-dynamic
  pgbouncer_LDFLAGS := $(TLS_LDFLAGS)
 -pgbouncer_LDADD := $(CARES_LIBS) $(LIBEVENT_LIBS) $(TLS_LIBS) $(LIBS)
 +pgbouncer_LDADD := $(CARES_LIBS) $(LIBEVENT_LIBS) $(TLS_LIBS) $(LIBS) $(python_LDFLAGS)


### PR DESCRIPTION
*Issue #, if available: configure was failing

*Description of changes:*
Makefile pointed to python 3.8 so changed it to python3.9, the default amazon linux 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
