### PR TITLE
Add an optional db-key parameter to the routing and rewriting function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The Python routing function is dynamically loaded by pgbouncer-rr, from the file
 
 The file should contain the following Python function:    
 `def routing_rules(username, query):`  
-- The function parameters will provide the username associated with the client, and a query string.
+- The function parameters will provide the username associated with the client, and a query string
+- The function may take optonally a database key name parameter:
+  - In this case the file should contain the following Python function: `def routing_rules(username, query, db_key):` the db_key argument will be the name of the database key used for the query.
 - The function return value must be a valid database key name (dbkey) as specified in the configuration file, or `None`:
   - When a valid dbkey is returned by the routing function, the client connection will be routed to a connection in the specified server connection pool. 
   - When `None` is returned by the routing function, the client remains routed to its current server connection.   


### PR DESCRIPTION
*Description of changes:*

Add an optional parameter to the routing and rewriting functions. In this case we can use `def routing_rules(username, query, db_key):` the db_key argument will be the name of the database key used for the query. If no parameter Is supplied it works as usual.

Consider the following scenario, we want to perform routing for the Amazon Redshift cluster 1 and Amazon Redshift cluster 2, but for Amazon Redshift cluster 3 no routing is necessary. In this case we need the database name from the client query.

```
[databases]
dev = host=<redshift1> port=5439 dbname=dev
dev.1 = host=<redshift1> port=5439 dbname=dev
dev.2 = host=<redshift2> port=5439 dbname=dev

testing = host=<redshift3> port=5439 dbname=testing
```
Ensure the configuration file setting `routing_rules_py_module_file` specifies the path to your python routing function file, such as `~/routing_rules.py`.
 
The code in the file could look like the following:
```
def routing_rules(username, query, db_key):
    if db_key != 'testing':
        if "tablea" in query:
            return "dev.1"
        elif "tableb" in query:
            return "dev.2"
    return None
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
