### PR TITLE
fix error with the awscli installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /home/pgbouncer
 
 #Install aws cli
 RUN cd /home/pgbouncer
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN mkdir /home/pgbouncer/.aws


### PR DESCRIPTION
*Issue #, if available:*

*Update awscli installation step*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Error To Resolve
```
Step 14/21 : RUN chmod +x ./aws/install &&     ./aws/install
 ---> Running in 375dd6caf2fd
./aws/install: line 78: /home/pgbouncer/aws/dist/aws: cannot execute binary file: Exec format error
```
