### PR TITLE
Fix broken curl and pkg-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2022
 
-RUN yum -y update 
-RUN yum install -y tar net-tools curl vim unzip less libevent-devel openssl-devel python-devel libtool git patch make
+RUN yum -y update
+RUN yum install -y tar net-tools curl vim unzip less libevent-devel openssl-devel python-devel libtool git patch make gcc --allowerasing
 RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "pgbouncer_1_15_0" && \
     git clone https://github.com/awslabs/pgbouncer-rr-patch.git && \
     cd pgbouncer-rr-patch && \
@@ -10,13 +10,14 @@ RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "pgbouncer_1_1
     git submodule init && \
     git submodule update && \
     ./autogen.sh && \
-    ./configure --prefix=/usr/local && \
+    ln -s /usr/bin/x86_64-amazon-linux-gnu-pkg-config /usr/bin/x86_64-redhat-linux-gnu-pkg-config && \
+    ./configure --prefix=/usr/local --exec-prefix=/usr/bin && \
     make && \
     make install
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
 RUN chmod +x ./kubectl && \
-    mv kubectl /usr/sbin 
+    mv kubectl /usr/sbin
 RUN chmod 777 -R /usr/local/
 
 # Installed with pgbouncer
@@ -29,7 +30,7 @@ WORKDIR /home/pgbouncer
 
 #Install aws cli
 RUN cd /home/pgbouncer
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN mkdir /home/pgbouncer/.aws


### PR DESCRIPTION
#Issue
curl is broken, it needs `--allowerasing`. pkg-config is broken.

*Description of changes:*
 I fixed it with the symlink, see line 13.  exec_prefix was set to none, with --exec-prefix=/usr/bin pkg-config can be found.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
