### PR TITLE
Fix Dockerfile to install pandoc and compile on top of pgbouncer stable-1.19 and deploy with EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-#FROM ubuntu:14.04
-#RUN  apt-get update \
-#  && apt-get install -y wget \
-#  && rm -rf /var/lib/apt/lists/*
 FROM public.ecr.aws/amazonlinux/amazonlinux:2022
 
 RUN yum -y update
-RUN yum install -y wget
-RUN yum install -y tar net-tools curl vim unzip less libevent-devel openssl-devel python-devel libtool git patch make gcc --allowerasing
+RUN yum install -y tar net-tools curl vim unzip less libevent-devel openssl-devel python-devel libtool git patch make gcc wget --allowerasing
+# Install pandoc
 RUN wget https://github.com/jgm/pandoc/releases/download/3.1.6.2/pandoc-3.1.6.2-linux-amd64.tar.gz && \
     tar xvzf ./pandoc-3.1.6.2-linux-amd64.tar.gz --strip-components 1 -C /usr/local
 RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19" && \
@@ -17,7 +13,7 @@ RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19" 
     git submodule init && \
     git submodule update && \
     ./autogen.sh && \
-    #ln -s /usr/bin/x86_64-amazon-linux-gnu-pkg-config /usr/bin/x86_64-redhat-linux-gnu-pkg-config && \
+    ln -s /usr/bin/x86_64-amazon-linux-gnu-pkg-config /usr/bin/x86_64-redhat-linux-gnu-pkg-config && \
     ./configure --prefix=/usr/local --exec-prefix=/usr/bin && \
     make && \
     make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
+#FROM ubuntu:14.04
+#RUN  apt-get update \
+#  && apt-get install -y wget \
+#  && rm -rf /var/lib/apt/lists/*
 FROM public.ecr.aws/amazonlinux/amazonlinux:2022
 
 RUN yum -y update
+RUN yum install -y wget
 RUN yum install -y tar net-tools curl vim unzip less libevent-devel openssl-devel python-devel libtool git patch make gcc --allowerasing
-RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "pgbouncer_1_15_0" && \
+RUN wget https://github.com/jgm/pandoc/releases/download/3.1.6.2/pandoc-3.1.6.2-linux-amd64.tar.gz && \
+    tar xvzf ./pandoc-3.1.6.2-linux-amd64.tar.gz --strip-components 1 -C /usr/local
+RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19" && \
     git clone https://github.com/awslabs/pgbouncer-rr-patch.git && \
     cd pgbouncer-rr-patch && \
     ./install-pgbouncer-rr-patch.sh ../pgbouncer && \
@@ -10,7 +17,7 @@ RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "pgbouncer_1_1
     git submodule init && \
     git submodule update && \
     ./autogen.sh && \
-    ln -s /usr/bin/x86_64-amazon-linux-gnu-pkg-config /usr/bin/x86_64-redhat-linux-gnu-pkg-config && \
+    #ln -s /usr/bin/x86_64-amazon-linux-gnu-pkg-config /usr/bin/x86_64-redhat-linux-gnu-pkg-config && \
     ./configure --prefix=/usr/local --exec-prefix=/usr/bin && \
     make && \
     make install

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Download and install pgbouncer-rr by running the following commands (Amazon Linu
 # install required packages - see https://github.com/pgbouncer/pgbouncer#building
 sudo yum install libevent-devel openssl-devel python-devel libtool git patch make -y
 
-# download the latest tested pgbouncer distribution - 1.12
+# download the latest tested pgbouncer distribution - 1.19
 git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19"
 
 # download pgbouncer-rr extensions

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ The Kubernetes Service,[pgbouncer-svc.yaml](./pgbouncer-svc.yaml) uses Network L
 ### Deployment steps
 The EKS option automates the configuration and installation sections above. The deployment steps with EKS are:
 
-* [Deploy EKS cluster with Karpenter for automatic EC2 instance horizontal scaling](https://karpenter.sh/v0.13.2/getting-started/getting-started-with-eksctl/)
+* [Deploy EKS cluster with Karpenter for automatic EC2 instance horizontal scaling](https://karpenter.sh/v0.29/getting-started/getting-started-with-karpenter/)
 
 * [Install the AWS Load Balancer Controller add-on](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
 


### PR DESCRIPTION
Fixing the Dockerfile to compile on top of pgbouncer stable-1.19 and deploy with EKS. Also fixing a broken link in the readme. 

Fixing the dockerfile entailed updating the script to clone from a more recent stable branch of pgbouncer, and adding a command to install pandoc. In theory, other pgbouncer changes can easily be run and pushed by just editing the branch appropriately in this script.

_____

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
