### PR TITLE
Upgrade pgbouncer to 1.23

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -7,7 +7,7 @@ RUN yum install -y tar net-tools curl vim unzip less libevent-devel openssl-deve
 RUN ARCH="" && if [ "$(uname -m)" = "x86_64" ]; then ARCH='amd64'; else ARCH='arm64'; fi && export ${ARCH} && \
     wget https://github.com/jgm/pandoc/releases/download/3.1.6.2/pandoc-3.1.6.2-linux-${ARCH}.tar.gz && \
     tar xvzf ./pandoc-3.1.6.2-linux-${ARCH}.tar.gz --strip-components 1 -C /usr/local
-RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19" && \
+RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.23" && \
     git clone https://github.com/awslabs/pgbouncer-rr-patch.git && \
     cd pgbouncer-rr-patch && \
     ./install-pgbouncer-rr-patch.sh ../pgbouncer && \

--- a/Makefile.diff
+++ b/Makefile.diff
@@ -1,18 +1,18 @@
 diff --git a/Makefile b/Makefile
-index 00773da..981e06a 100644
+index e7c694d..172c463 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -21,6 +21,9 @@ pgbouncer_SOURCES = \
+@@ -23,6 +23,9 @@ pgbouncer_SOURCES = \
  	src/server.c \
  	src/stats.c \
  	src/system.c \
-+        src/pycall.c \
-+        src/route_connection.c \
-+        src/rewrite_query.c \
++	src/pycall.c \
++	src/route_connection.c \
++	src/rewrite_query.c \
  	src/takeover.c \
  	src/util.c \
  	src/varcache.c \
-@@ -47,6 +50,9 @@ pgbouncer_SOURCES = \
+@@ -53,6 +56,9 @@ pgbouncer_SOURCES = \
  	include/server.h \
  	include/stats.h \
  	include/system.h \
@@ -22,17 +22,17 @@ index 00773da..981e06a 100644
  	include/takeover.h \
  	include/util.h \
  	include/varcache.h \
-@@ -59,7 +65,8 @@ pgbouncer_SOURCES = \
- 	include/common/unicode_norm.h \
- 	include/common/unicode_norm_table.h
+@@ -68,7 +74,8 @@ pgbouncer_SOURCES = \
+ 	include/common/uthash_lowercase.h
  
+ UTHASH = uthash
 -pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS)
 +python_CPPFLAGS = -I/usr/include/python3.9 -I/usr/include/python3.9
 +pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS) $(python_CPPFLAGS)
+ pgbouncer_CPPFLAGS += -I$(UTHASH)/src
  
  # include libusual sources directly
- AM_FEATURES = libusual
-@@ -71,6 +78,8 @@ dist_doc_DATA = README.md NEWS.md \
+@@ -81,6 +88,8 @@ dist_doc_DATA = README.md NEWS.md \
  	etc/pgbouncer.ini \
  	etc/pgbouncer.service \
  	etc/pgbouncer.socket \
@@ -41,15 +41,14 @@ index 00773da..981e06a 100644
  	etc/userlist.txt
  
  DISTCLEANFILES = config.mak config.status lib/usual/config.h config.log
-@@ -98,8 +107,10 @@ LIBUSUAL_DIST = $(filter-out %/config.h, $(sort $(wildcard \
- 		lib/README lib/COPYRIGHT \
- 		lib/find_modules.sh )))
+@@ -112,8 +121,9 @@ LIBUSUAL_DIST = $(filter-out %/config.h, $(sort $(wildcard \
+ UTHASH_DIST = $(UTHASH)/src/uthash.h \
+               $(UTHASH)/LICENSE
  
 +python_LDFLAGS = -lpthread -ldl -lutil -lm -lpython3.9 -Xlinker -export-dynamic
  pgbouncer_LDFLAGS := $(TLS_LDFLAGS)
 -pgbouncer_LDADD := $(CARES_LIBS) $(LIBEVENT_LIBS) $(TLS_LIBS) $(LIBS)
 +pgbouncer_LDADD := $(CARES_LIBS) $(LIBEVENT_LIBS) $(TLS_LIBS) $(LIBS) $(python_LDFLAGS)
-+
  LIBS :=
  
  #

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ Download and install pgbouncer-fast-switchover by running the following commands
 # install required packages - see https://github.com/pgbouncer/pgbouncer#building
 sudo yum install libevent-devel openssl-devel python-devel libtool git patch make -y
 
-# download the latest tested pgbouncer distribution - 1.19
-git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19"
+# download the latest tested pgbouncer distribution - 1.23
+git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.23"
 
 # download pgbouncer-fast-switchover extensions
 git clone https://github.com/awslabs/pgbouncer-fast-switchover.git
@@ -489,14 +489,14 @@ export BASE_TAG=multiarch-al2
 export BASE_ARM_TAG=arm64
 export BASE_AMD_TAG=amd64
 export PGB_REPO=pgbouncer
-export PGB_TAG=fastswitchover.pg.stable.1.19.multiarch
+export PGB_TAG=fastswitchover.pg.stable.1.23.multiarch
 export PGB_ARM_TAG=arm64
 export PGB_AMD_TAG=amd64
 export GITHUB_OWNER=awslabs
 export GITHUB_BRANCH=ci-build
 export GITHUB_REPO=pgbouncer-fast-switchover
 export PANDOC_VER=3.1.7
-export PGB_GITHUB_BRANCH=stable-1.19
+export PGB_GITHUB_BRANCH=stable-1.23
 ```
 
 NEED Fix 4 :2/ Build pipeline for the base image

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,8 +1,8 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index f2c2bac..6f45879 100644
+index 62e49bf..1b8b360 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
-@@ -99,6 +99,11 @@ typedef struct ScramState ScramState;
+@@ -161,6 +161,11 @@ typedef enum ReplicationType ReplicationType;
  
  extern int cf_sbuf_len;
  
@@ -14,48 +14,52 @@ index f2c2bac..6f45879 100644
  #include "util.h"
  #include "iobuf.h"
  #include "sbuf.h"
-@@ -374,12 +379,31 @@ struct PgPool {
+@@ -461,12 +466,33 @@ struct PgPool {
  
  	/* if last connect to server failed, there should be delay before next */
  	usec_t last_connect_time;
+-	bool last_connect_failed : 1;
+-	bool last_login_failed : 1;
 +	usec_t last_poll_time;
 +	usec_t last_failed_time; // last time the connection failed
- 	bool last_connect_failed:1;
- 	bool last_login_failed:1;
- 
- 	bool welcome_msg_ready:1;
--
-+	bool recently_checked:1; // should be set once checking starts. If all pools have this set, they need to be unset so we can loop again.
++	bool last_connect_failed:1;
++	bool last_login_failed:1;
++
++	bool welcome_msg_ready:1;
++
++	bool recently_checked:1;		  // should be set once checking starts. If all pools have this set, they need to be unset so we can loop again.
 +	bool initial_writer_endpoint:1; // used to indicate a configured writer when starting PgBouncer. Used for getting the topology of the cluster associated with the writer.
-+	bool refresh_topology:1; // after a new writer is found, indicate that we need to refresh the topology.
++	bool refresh_topology:1;		  // after a new writer is found, indicate that we need to refresh the topology.
 +	/*
 +	 * Used to indicate that DataRow, CommandComplete, and ReadyForQuery should be discarded.
 +	 * This is for the case where the topology has to be refreshed, but the data should not be
 +	 * sent to the client.
-+	 * 
++	 *
 +	 * Once the ReadyForQuery is received, all topology data has been discarded and regular
 +	 * client server communications can resume.
-+	*/
-+	bool collect_datarows:1; 
++	 */
++	bool collect_datarows:1;
 +	bool checking_for_new_writer:1; // this is linked with server and client so we can communicate when polling is truly done. Used to only allow checking for one node a time.
-+
+ 
+-	bool welcome_msg_ready : 1;
 +	uint16_t num_nodes;
+ 
  	uint16_t rrcounter;		/* round-robin counter */
 +
-+	PgPool *global_writer;	/* global_writer pool for this pool */;
++	PgPool *global_writer;	/* global_writer pool for this pool */
 +	PgPool *parent_pool;	/* the parent pool for setting the global writer */
  };
  
  /*
-@@ -466,6 +490,7 @@ struct PgDatabase {
- 	int pool_mode;		/* pool mode for this database */
+@@ -568,6 +594,7 @@ struct PgDatabase {
  	int max_db_connections;	/* max server connections between all pools */
+ 	usec_t server_lifetime;	/* max lifetime of server connection */
  	char *connect_query;	/* startup commands to send to server after connect */
 +	char *topology_query;	/* command to get topology to determine promoted writer. Also used to indicate whether to use fast_switchovers on a specific node */
  
- 	struct PktBuf *startup_params; /* partial StartupMessage (without user) be sent to server */
+ 	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
  	const char *dbname;	/* server-side name, pointer to inside startup_msg */
-@@ -598,7 +623,9 @@ extern int cf_peer_id;
+@@ -765,7 +792,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -65,15 +69,15 @@ index f2c2bac..6f45879 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -615,6 +642,7 @@ extern int cf_server_reset_query_always;
- extern char * cf_server_check_query;
+@@ -782,6 +811,7 @@ extern int cf_server_reset_query_always;
+ extern char *cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
 +extern usec_t cf_server_failed_delay;
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -667,6 +695,11 @@ extern int cf_log_disconnections;
+@@ -834,6 +864,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/loader.h.diff
+++ b/include/loader.h.diff
@@ -1,10 +1,10 @@
 diff --git a/include/loader.h b/include/loader.h
-index dabfc51..8f7ed38 100644
+index 1acbefe..ddb044f 100644
 --- a/include/loader.h
 +++ b/include/loader.h
 @@ -25,3 +25,5 @@ bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
  /* user file parsing */
- bool load_auth_file(const char *fn)  /* _MUSTCHECK */;
- bool loader_users_check(void)  /* _MUSTCHECK */;
+ bool load_auth_file(const char *fn) /* _MUSTCHECK */;
+ bool loader_users_check(void) /* _MUSTCHECK */;
 +
 +PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname);

--- a/include/objects.h.diff
+++ b/include/objects.h.diff
@@ -1,11 +1,11 @@
 diff --git a/include/objects.h b/include/objects.h
-index 7f64ce1..9737490 100644
+index 3ff3376..68a3cfb 100644
 --- a/include/objects.h
 +++ b/include/objects.h
-@@ -32,6 +32,7 @@ extern struct Slab *peer_pool_cache;
- extern struct Slab *pool_cache;
- extern struct Slab *user_cache;
- extern struct Slab *iobuf_cache;
+@@ -37,6 +37,7 @@ extern struct Slab *outstanding_request_cache;
+ extern struct Slab *var_list_cache;
+ extern struct Slab *server_prepared_statement_cache;
+ extern PgPreparedStatement *prepared_statements;
 +extern bool fast_switchover;
  
  PgDatabase *find_peer(int peer_id);

--- a/include/pktbuf.h.diff
+++ b/include/pktbuf.h.diff
@@ -1,13 +1,12 @@
 diff --git a/include/pktbuf.h b/include/pktbuf.h
-index fbe1fc5..83d9587 100644
+index 4e0b313..60cacb7 100644
 --- a/include/pktbuf.h
 +++ b/include/pktbuf.h
-@@ -47,6 +47,8 @@ void pktbuf_free(PktBuf *buf);
+@@ -47,6 +47,7 @@ void pktbuf_free(PktBuf *buf);
  void pktbuf_reset(struct PktBuf *pkt);
  struct PktBuf *pktbuf_temp(void);
  
 +PktBuf *pktbuf_copy(PktBuf *orig);
-+
  
  /*
   * sending

--- a/include/util.h.diff
+++ b/include/util.h.diff
@@ -1,10 +1,10 @@
 diff --git a/include/util.h b/include/util.h
-index 35a284b..32e9782 100644
+index 387d706..4f7a132 100644
 --- a/include/util.h
 +++ b/include/util.h
-@@ -19,6 +19,16 @@
- #include <usual/logging.h>
+@@ -20,6 +20,16 @@
  #include <usual/string.h>
+ #include <usual/cfparser.h>
  
 +/*
 + * sets the global writer to NULL for the pool

--- a/install-pgbouncer-rr-patch.sh
+++ b/install-pgbouncer-rr-patch.sh
@@ -89,8 +89,8 @@ if [ $patchstatus -eq 1 ]; then
    echo "Possible causes: "
    echo "   pgbouncer-rr-patch already installed in target directory?"
    echo "   new version of pgbouncer with changed source files that can't be patched?"
-   echo "      - last tested with pgbouncer v1.19 (September 2023)"
-   echo "      - Try getting pgbouncer with: git clone https://github.com/pgbouncer/pgbouncer.git --branch \"stable-1.19\""
+   echo "      - last tested with pgbouncer v1.23 (August 2024)"
+   echo "      - Try getting pgbouncer with: git clone https://github.com/pgbouncer/pgbouncer.git --branch \"stable-1.23\""
    echo "Status: pgbouncer-rr-patch merge FAILED"
 else
    echo "Status: pgbouncer-rr-patch merge SUCEEDED"

--- a/src/admin.c.diff
+++ b/src/admin.c.diff
@@ -1,8 +1,8 @@
 diff --git a/src/admin.c b/src/admin.c
-index 0cf2e8b..c4dbfde 100644
+index cac7b84..7f7207e 100644
 --- a/src/admin.c
 +++ b/src/admin.c
-@@ -1093,6 +1093,7 @@ static bool admin_cmd_reload(PgSocket *admin, const char *arg)
+@@ -1117,6 +1117,7 @@ static bool admin_cmd_reload(PgSocket *admin, const char *arg)
  	load_config();
  	if (!sbuf_tls_setup())
  		log_error("TLS configuration could not be reloaded, keeping old configuration");

--- a/src/client.c.diff
+++ b/src/client.c.diff
@@ -1,21 +1,8 @@
 diff --git a/src/client.c b/src/client.c
-index 464d78d..ff64c08 100644
+index ac13a48..6057c8a 100644
 --- a/src/client.c
 +++ b/src/client.c
-@@ -585,10 +585,10 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
- 		} else if (strcmp(key, "application_name") == 0) {
- 			set_appname(client, val);
- 			appname_found = true;
--		} else if (varcache_set(&client->vars, key, val)) {
--			slog_debug(client, "got var: %s=%s", key, val);
- 		} else if (strlist_contains(cf_ignore_startup_params, key)) {
- 			slog_debug(client, "ignoring startup parameter: %s=%s", key, val);
-+		} else if (varcache_set(&client->vars, key, val)) {
-+			slog_debug(client, "got var: %s=%s", key, val);
- 		} else {
- 			slog_warning(client, "unsupported startup parameter: %s=%s", key, val);
- 			disconnect_client(client, true, "unsupported startup parameter: %s", key);
-@@ -798,7 +798,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
+@@ -1106,7 +1106,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
  			return false;
  		}
  
@@ -24,16 +11,15 @@ index 464d78d..ff64c08 100644
  			disconnect_client(client, true, "client re-sent startup pkt");
  			return false;
  		}
-@@ -923,7 +923,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
- static bool handle_client_work(PgSocket *client, PktHdr *pkt)
- {
- 	SBuf *sbuf = &client->sbuf;
--	int rfq_delta = 0;
-+	int rfq_delta = 0, in_transaction;
+@@ -1234,6 +1234,7 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+ 	int track_outstanding = false;
+ 	PreparedStatementAction ps_action = PS_IGNORE;
+ 	PgClosePacket close_packet;
++	bool in_transaction = false;
  
  	switch (pkt->type) {
- 
-@@ -980,8 +980,11 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+ 	/* one-packet queries */
+@@ -1397,8 +1398,11 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  		client->query_start = get_cached_time();
  	}
  
@@ -46,7 +32,7 @@ index 464d78d..ff64c08 100644
  		client->pool->stats.xact_count++;
  		client->xact_start = client->query_start;
  	}
-@@ -989,6 +992,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+@@ -1406,6 +1410,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  	if (client->pool->db->admin)
  		return admin_handle_client(client, pkt);
  

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 855a4c5..1e02db8 100644
+index 0bdc729..170853e 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
 @@ -24,6 +24,8 @@
@@ -11,7 +11,7 @@ index 855a4c5..1e02db8 100644
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
  static struct event full_maint_ev;
-@@ -125,21 +127,158 @@ void resume_all(void)
+@@ -125,21 +127,159 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -23,8 +23,8 @@ index 855a4c5..1e02db8 100644
 +	if (client->pool == new_pool)
 +		return true;
 +
-+	username = client->login_user->name;
-+	passwd = client->login_user->passwd;
++	username = client->login_user_credentials->name;
++	passwd = client->login_user_credentials->passwd;
 +	if (!set_pool(client, new_pool->db->name, username, passwd, true)) {
 +		log_error("could not set pool to: %s", new_pool->db->name);
 +		return false;
@@ -114,10 +114,10 @@ index 855a4c5..1e02db8 100644
 +
 +			last_poll_time = next_pool->last_poll_time;
 +			difference_in_ms = (now - last_poll_time) / 1000;
-+			log_debug("launch_recheck: last time checked for pool %s: now: %llu last: %llu, diff: %llu, polling_freq_max: %llu", next_pool->db->name, now, last_poll_time, difference_in_ms, cf_polling_frequency/1000);
++			log_debug("launch_recheck: last time checked for pool %s: now: %lu last: %lu, diff: %lu, polling_freq_max: %lu", next_pool->db->name, now, last_poll_time, difference_in_ms, cf_polling_frequency/1000);
 +
 +			if (difference_in_ms < polling_freq_in_ms) {
-+				log_debug("launch_recheck: skipping because it's too soon for pool %s (%llu ms)", next_pool->db->name, difference_in_ms);
++				log_debug("launch_recheck: skipping because it's too soon for pool %s (%lu ms)", next_pool->db->name, difference_in_ms);
 +				continue;
 +			}
 +
@@ -156,6 +156,7 @@ index 855a4c5..1e02db8 100644
 +			next_pool->recently_checked = true;
 +		}
 +	}
++
  
  	/* find clean server */
  	while (1) {
@@ -176,7 +177,7 @@ index 855a4c5..1e02db8 100644
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -154,6 +293,31 @@ static void launch_recheck(PgPool *pool)
+@@ -154,6 +294,32 @@ static void launch_recheck(PgPool *pool)
  			need_check = false;
  	}
  
@@ -205,10 +206,11 @@ index 855a4c5..1e02db8 100644
 +		}
 +	}
 +
++
  	if (need_check) {
  		/* send test query, wait for result */
  		slog_debug(server, "P: checking: %s", q);
-@@ -202,11 +366,22 @@ static void per_loop_activate(PgPool *pool)
+@@ -208,11 +374,21 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -221,7 +223,7 @@ index 855a4c5..1e02db8 100644
 +			log_debug("launch_new_connection because not enough connections. number pools: %d, for: %s", statlist_count(&pool_list), pool->db->name);
 +
 +			if (fast_switchover && pool->db->topology_query &&
-+			 	(!get_global_writer(pool) || pool->last_connect_failed)) {
++				(!get_global_writer(pool) || pool->last_connect_failed)) {
 +				log_debug("launch_new_connection loop: going to try to use pool cache since this pool was a writer: last_connect_failed (%d)",
 +						pool->last_connect_failed);
 +				launch_recheck(pool, client);
@@ -229,11 +231,10 @@ index 855a4c5..1e02db8 100644
 +				log_debug("launch_new_connection loop: need to launch new connection because pool is not already a writer");
 +				launch_new_connection(pool, /* evict_if_needed= */ true);
 +			}
-+
  			break;
  		}
  	}
-@@ -298,10 +473,7 @@ static int per_loop_wait_close(PgPool *pool)
+@@ -304,10 +480,7 @@ static int per_loop_wait_close(PgPool *pool)
  	return count;
  }
  
@@ -245,7 +246,7 @@ index 855a4c5..1e02db8 100644
  {
  	struct List *item;
  	PgPool *pool;
-@@ -310,6 +482,7 @@ void per_loop_maint(void)
+@@ -316,6 +489,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -253,7 +254,7 @@ index 855a4c5..1e02db8 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -321,13 +494,32 @@ void per_loop_maint(void)
+@@ -327,13 +501,32 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -287,7 +288,7 @@ index 855a4c5..1e02db8 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -366,6 +558,27 @@ void per_loop_maint(void)
+@@ -372,6 +565,27 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -315,17 +316,17 @@ index 855a4c5..1e02db8 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -472,6 +685,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -482,6 +696,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
 +			   && (pool->db && !pool->db->topology_query)
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
- 		} else if (age >= cf_server_lifetime) {
-@@ -801,6 +1015,7 @@ void kill_database(PgDatabase *db)
- 	if (db->forced_user)
- 		slab_free(user_cache, db->forced_user);
+ 		} else if (age >= server_lifetime) {
+@@ -846,6 +1061,7 @@ void kill_database(PgDatabase *db)
+ 	if (db->forced_user_credentials)
+ 		slab_free(credentials_cache, db->forced_user_credentials);
  	free(db->connect_query);
 +	free(db->topology_query);
  	if (db->inactive_time) {

--- a/src/loader.c.diff
+++ b/src/loader.c.diff
@@ -1,8 +1,8 @@
 diff --git a/src/loader.c b/src/loader.c
-index 55f87a8..4db4b57 100644
+index be058ce..6202ada 100644
 --- a/src/loader.c
 +++ b/src/loader.c
-@@ -61,12 +61,20 @@ static char *cstr_unquote_value(char *p)
+@@ -54,12 +54,20 @@ static char *cstr_unquote_value(char *p)
  	while (1) {
  		if (!*p)
  			return NULL;
@@ -23,11 +23,10 @@ index 55f87a8..4db4b57 100644
  		*s++ = *p++;
  	}
  	/* terminate actual value */
-@@ -260,6 +268,76 @@ fail:
- 	free(tmp_connstr);
- 	return false;
+@@ -165,6 +173,75 @@ static bool set_autodb(const char *connstr)
+ 	return true;
  }
-+
+ 
 +PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname)
 +{
 +	PgPool *pool;
@@ -79,14 +78,14 @@ index 55f87a8..4db4b57 100644
 +			goto oom;
 +	}
 +
-+	if (db->forced_user) {
-+		if (!force_user(new_db, db->forced_user->name, db->forced_user->passwd)) {;
++	if (db->forced_user_credentials) {
++		if (!force_user_credentials(new_db, db->forced_user_credentials->name, db->forced_user_credentials->passwd)) {;
 +			goto oom;
 +		}
 +	}
 +
 +	log_debug("creating pool for %s", new_db->name);
-+	pool = get_pool(new_db, new_db->forced_user);
++	pool = get_pool(new_db, new_db->forced_user_credentials);
 +	if (!pool) {
 +		fatal("pool could not be created for %s", new_db->name);
 +		goto oom;
@@ -98,17 +97,17 @@ index 55f87a8..4db4b57 100644
 +}
 +
  /* fill PgDatabase from connstr */
- bool parse_database(void *base, const char *name, const char *connstr)
+ bool parse_peer(void *base, const char *name, const char *connstr)
  {
-@@ -286,6 +364,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -269,6 +346,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	char *datestyle = NULL;
  	char *timezone = NULL;
  	char *connect_query = NULL;
 +	char *topology_query = NULL;
  	char *appname = NULL;
+ 	char *auth_query = NULL;
  
- 	cv.value_p = &pool_mode;
-@@ -358,11 +437,26 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -344,11 +422,27 @@ bool parse_database(void *base, const char *name, const char *connstr)
  				goto fail;
  			}
  		} else if (strcmp("connect_query", key) == 0) {
@@ -116,6 +115,7 @@ index 55f87a8..4db4b57 100644
 +				log_error("connect_query cannot be used if topology_query is set");
 +				goto fail;
 +			}
++
  			connect_query = strdup(val);
  			if (!connect_query) {
  				log_error("out of memory");
@@ -134,8 +134,8 @@ index 55f87a8..4db4b57 100644
 +			fast_switchover = true;
  		} else if (strcmp("application_name", key) == 0) {
  			appname = val;
- 		} else {
-@@ -400,6 +494,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 		} else if (strcmp("auth_query", key) == 0) {
+@@ -388,6 +482,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
  			changed = true;
  		} else if (!strings_equal(connect_query, db->connect_query)) {
  			changed = true;
@@ -143,24 +143,24 @@ index 55f87a8..4db4b57 100644
 +			changed = true;
  		} else if (!strings_equal(db->auth_dbname, auth_dbname)) {
  			changed = true;
- 		}
-@@ -416,7 +512,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
- 	db->pool_mode = pool_mode;
+ 		} else if (!strings_equal(db->auth_query, auth_query)) {
+@@ -407,7 +503,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	db->max_db_connections = max_db_connections;
+ 	db->server_lifetime = server_lifetime;
  	free(db->connect_query);
 +	free(db->topology_query);
  	db->connect_query = connect_query;
 +	db->topology_query = topology_query;
  
- 	if (!set_auth_dbname(db, auth_dbname))
+ 	if (!set_param_value(&db->auth_dbname, auth_dbname))
  		goto fail;
-@@ -476,6 +574,13 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -470,6 +568,13 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	/* remember dbname */
  	db->dbname = (char *)msg->buf + dbname_ofs;
  
 +	log_debug("creating pool for %s", db->name);
-+	if (db->forced_user) {
-+		PgPool *pool = get_pool(db, db->forced_user);
++	if (db->forced_user_credentials) {
++		PgPool *pool = get_pool(db, db->forced_user_credentials);
 +		if (!pool)
 +			fatal("pool could not be created for %s", db->name);
 +	}

--- a/src/main.c.diff
+++ b/src/main.c.diff
@@ -1,8 +1,8 @@
 diff --git a/src/main.c b/src/main.c
-index 3fc1a0c..dba92f2 100644
+index e5b9cd0..fbaee9d 100644
 --- a/src/main.c
 +++ b/src/main.c
-@@ -119,7 +119,9 @@ char *cf_auth_dbname;
+@@ -122,7 +122,9 @@ char *cf_track_extra_parameters;
  
  int cf_max_client_conn;
  int cf_default_pool_size;
@@ -12,7 +12,7 @@ index 3fc1a0c..dba92f2 100644
  int cf_res_pool_size;
  usec_t cf_res_pool_timeout;
  int cf_max_db_connections;
-@@ -130,6 +132,7 @@ int cf_server_reset_query_always;
+@@ -133,6 +135,7 @@ int cf_server_reset_query_always;
  char *cf_server_check_query;
  usec_t cf_server_check_delay;
  int cf_server_fast_close;
@@ -20,7 +20,7 @@ index 3fc1a0c..dba92f2 100644
  int cf_server_round_robin;
  int cf_disable_pqexec;
  usec_t cf_dns_max_ttl;
-@@ -171,6 +174,11 @@ int cf_log_disconnections;
+@@ -174,6 +177,11 @@ int cf_log_disconnections;
  int cf_log_pooler_errors;
  int cf_application_name_add_host;
  
@@ -32,35 +32,44 @@ index 3fc1a0c..dba92f2 100644
  int cf_client_tls_sslmode;
  char *cf_client_tls_protocols;
  char *cf_client_tls_ca_file;
-@@ -273,18 +281,27 @@ CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
- CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
- CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
- CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
-+// in seconds. maps to 100ms by default.
-+CF_ABS("polling_frequency", CF_TIME_USEC, cf_polling_frequency, 0, ".1"),
- CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
- CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
- CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
- CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
-+CF_ABS("recreate_disconnected_pools", DEFER_OPS, cf_recreate_disconnected_pools, 0, "1"),
- CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
- CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
- CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
-+/* pgbouncer-rr extensions */
-+CF_ABS("routing_rules_py_module_file", CF_STR, cf_routing_rules_py_module_file, 0, "not_enabled"),
-+CF_ABS("rewrite_query_py_module_file", CF_STR, cf_rewrite_query_py_module_file, 0, "not_enabled"),
-+CF_ABS("rewrite_query_disconnect_on_failure", CF_STR, cf_rewrite_query_disconnect_on_failure, 0, "false"),
- CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
- CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
- CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
- CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
- CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
-+// allow backing off after switchover/failover. The delay to wait until reopening failed connections.
-+CF_ABS("server_failed_delay", CF_TIME_USEC, cf_server_failed_delay, 0, "30"),
- CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
- CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
- CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
-@@ -1040,6 +1057,8 @@ int main(int argc, char *argv[])
+@@ -280,18 +288,27 @@ static const struct CfKey bouncer_params [] = {
+ 	CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
+ 	CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
+ 	CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
++	// in seconds. maps to 100ms by default.
++	CF_ABS("polling_frequency", CF_TIME_USEC, cf_polling_frequency, 0, ".1"),
+ 	CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
+ 	CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
+ 	CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
+ 	CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
++	CF_ABS("recreate_disconnected_pools", DEFER_OPS, cf_recreate_disconnected_pools, 0, "1"),
+ 	CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
+ 	CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
+ 	CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
++	/* pgbouncer-rr extensions */
++	CF_ABS("routing_rules_py_module_file", CF_STR, cf_routing_rules_py_module_file, 0, "not_enabled"),
++	CF_ABS("rewrite_query_py_module_file", CF_STR, cf_rewrite_query_py_module_file, 0, "not_enabled"),
++	CF_ABS("rewrite_query_disconnect_on_failure", CF_STR, cf_rewrite_query_disconnect_on_failure, 0, "false"),
+ 	CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
+ 	CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
+ 	CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
+ 	CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
+ 	CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
++	// allow backing off after switchover/failover. The delay to wait until reopening failed connections.
++	CF_ABS("server_failed_delay", CF_TIME_USEC, cf_server_failed_delay, 0, "30"),
+ 	CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
+ 	CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
+ 	CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
+@@ -305,7 +322,7 @@ static const struct CfKey bouncer_params [] = {
+ 	CF_ABS("server_tls_protocols", CF_STR, cf_server_tls_protocols, 0, "secure"),
+ 	CF_ABS("server_tls_sslmode", CF_LOOKUP(sslmode_map), cf_server_tls_sslmode, 0, "prefer"),
+ #ifdef WIN32
+-	CF_ABS("service_name", CF_STR, cf_jobname, CF_NO_RELOAD, NULL),	/* alias for job_name */
++	CF_ABS("service_name", CF_STR, cf_jobname, CF_NO_RELOAD, NULL), /* alias for job_name */
+ #endif
+ 	CF_ABS("so_reuseport", CF_INT, cf_so_reuseport, CF_NO_RELOAD, "0"),
+ 	CF_ABS("stats_period", CF_INT, cf_stats_period, 0, "60"),
+@@ -1097,6 +1114,8 @@ int main(int argc, char *argv[])
  	}
  
  	write_pidfile();

--- a/src/objects.c.diff
+++ b/src/objects.c.diff
@@ -1,17 +1,17 @@
 diff --git a/src/objects.c b/src/objects.c
-index ab662b8..e073699 100644
+index 015c3fc..dfed239 100644
 --- a/src/objects.c
 +++ b/src/objects.c
-@@ -643,14 +643,20 @@ PgPool *get_pool(PgDatabase *db, PgUser *user)
+@@ -753,14 +753,20 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials)
  {
  	struct List *item;
  	PgPool *pool;
 +	PgPool *global_writer = NULL;
  
- 	if (!db || !user)
+ 	if (!db || !user_credentials)
  		return NULL;
  
- 	list_for_each(item, &user->pool_list) {
+ 	list_for_each(item, &user_credentials->global_user->pool_list) {
  		pool = container_of(item, PgPool, map_head);
 -		if (pool->db == db)
 +		if (pool->db == db) {
@@ -23,19 +23,19 @@ index ab662b8..e073699 100644
 +		}
  	}
  
- 	return new_pool(db, user);
-@@ -854,6 +860,10 @@ bool life_over(PgSocket *server)
- 	usec_t age = now - server->connect_time;
+ 	return new_pool(db, user_credentials);
+@@ -1137,6 +1143,10 @@ bool life_over(PgSocket *server)
  	usec_t last_kill = now - pool->last_lifetime_disconnect;
+ 	usec_t server_lifetime = pool_server_lifetime(pool);
  
 +	// never close the pools when using fast switchovers
 +	if (pool->db && pool->db->topology_query)
 +		return false;
 +
- 	if (age < cf_server_lifetime)
+ 	if (age < server_lifetime)
  		return false;
  
-@@ -1589,6 +1599,8 @@ PgSocket *accept_client(int sock, bool is_unix)
+@@ -1964,6 +1974,8 @@ PgSocket *accept_client(int sock, bool is_unix)
  /* client managed to authenticate, send welcome msg and accept queries */
  bool finish_client_login(PgSocket *client)
  {
@@ -43,8 +43,8 @@ index ab662b8..e073699 100644
 +
  	if (client->db->fake) {
  		if (cf_log_connections)
- 			slog_info(client, "login failed: db=%s user=%s", client->db->name, client->login_user->name);
-@@ -1603,6 +1615,21 @@ bool finish_client_login(PgSocket *client)
+ 			slog_info(client, "login failed: db=%s user=%s", client->db->name, client->login_user_credentials->name);
+@@ -1978,6 +1990,22 @@ bool finish_client_login(PgSocket *client)
  
  	switch (client->state) {
  	case CL_LOGIN:
@@ -56,13 +56,14 @@ index ab662b8..e073699 100644
 +			log_debug("finish_client_login: no topology query, so not using fast switchover");
 +		} else if (global_writer) {
 +			log_debug("finish_client_login: global writer is set, so let's use the cached value: %s", global_writer->db->name);
-+			if (client->pool != global_writer && !set_pool(client, global_writer->db->name, client->login_user->name, client->login_user->passwd, true)) {
++			if (client->pool != global_writer && !set_pool(client, global_writer->db->name, client->login_user_credentials->name, client->login_user_credentials->passwd, true)) {
 +				log_error("could not set pool to: %s", global_writer->db->name);
 +				return false;
 +			}
 +		} else {
 +			log_debug("finish_client_login: done...activating client");
 +		}
++
  		change_client_state(client, CL_ACTIVE);
  	case CL_ACTIVE:
  		break;

--- a/src/pktbuf.c.diff
+++ b/src/pktbuf.c.diff
@@ -1,8 +1,8 @@
 diff --git a/src/pktbuf.c b/src/pktbuf.c
-index 7dfec56..c4a6080 100644
+index e54175e..490aa9b 100644
 --- a/src/pktbuf.c
 +++ b/src/pktbuf.c
-@@ -65,6 +65,37 @@ PktBuf *pktbuf_dynamic(int start_len)
+@@ -79,6 +79,37 @@ PktBuf *pktbuf_dynamic(int start_len)
  	return buf;
  }
  

--- a/src/pycall.c
+++ b/src/pycall.c
@@ -1,12 +1,12 @@
 /*
 Copyright 2015-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-Licensed under the Amazon Software License (the "License"). 
+Licensed under the Amazon Software License (the "License").
 You may not use this file except in compliance with the License. A copy of the License is located at
 
     http://aws.amazon.com/asl/
 
-or in the "license" file accompanying this file. 
+or in the "license" file accompanying this file.
 This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
@@ -44,8 +44,8 @@ char *pycall(PgSocket *client, char *username, char *query_str, int in_transacti
 		ext[0] = '\0';
 
 	/* Initialize the Python interpreter
-	 * NOTE: This call is a no-op on subsequent calls, as we do not 
-	 * call PyFinalize(). This 
+	 * NOTE: This call is a no-op on subsequent calls, as we do not
+	 * call PyFinalize(). This
 	 * a) avoids the overhead of repeatedly reloading the interpreter
 	 * b) allows the use of global variables for persisting data in the
 	 *    routing / rewriting functions between calls.
@@ -140,4 +140,3 @@ char *pycall(PgSocket *client, char *username, char *query_str, int in_transacti
 	Py_XDECREF(pValue);
 	return res;
 }
-

--- a/src/rewrite_query.c
+++ b/src/rewrite_query.c
@@ -80,13 +80,13 @@ bool rewrite_query(PgSocket *client, int in_transaction, PktHdr *pkt) {
 
     if (unlikely(cf_verbose > 0)) {
 	    loggable_query_str = strip_newlines(query_str) ;
-	    slog_debug(client, "rewrite_query: Username => %s", client->login_user->name);
+	    slog_debug(client, "rewrite_query: Username => %s", client->login_user_credentials->name);
 	    slog_debug(client, "rewrite_query: Orig Query=> %s", loggable_query_str);
 	    free(loggable_query_str);
 	}
 
 	/* call python function to rewrite the query */
-	tmp_new_query_str = pycall(client, client->login_user->name, query_str, in_transaction, cf_rewrite_query_py_module_file,
+	tmp_new_query_str = pycall(client, client->login_user_credentials->name, query_str, in_transaction, cf_rewrite_query_py_module_file,
 			"rewrite_query");
 	if (tmp_new_query_str == NULL) {
 		slog_debug(client, "query unchanged");

--- a/src/route_connection.c
+++ b/src/route_connection.c
@@ -1,12 +1,12 @@
 /*
 Copyright 2015-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-Licensed under the Amazon Software License (the "License"). 
+Licensed under the Amazon Software License (the "License").
 You may not use this file except in compliance with the License. A copy of the License is located at
 
     http://aws.amazon.com/asl/
 
-or in the "license" file accompanying this file. 
+or in the "license" file accompanying this file.
 This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
@@ -57,7 +57,7 @@ bool route_client_connection(PgSocket *client, int in_transaction, PktHdr *pkt) 
 		fatal("Invalid packet type - expected Q or P, got %c", pkt->type);
 	}
 
-	slog_debug(client, "route_client_connection: Username => %s", client->login_user->name);
+	slog_debug(client, "route_client_connection: Username => %s", client->login_user_credentials->name);
 	slog_debug(client, "route_client_connection: Query => %s", query_str);
 
 	if (strcmp(cf_routing_rules_py_module_file, "not_enabled") == 0) {
@@ -66,7 +66,7 @@ bool route_client_connection(PgSocket *client, int in_transaction, PktHdr *pkt) 
 		return true;
 	}
 
-	dbname = pycall(client, client->login_user->name, query_str, in_transaction, cf_routing_rules_py_module_file,
+	dbname = pycall(client, client->login_user_credentials->name, query_str, in_transaction, cf_routing_rules_py_module_file,
 			"routing_rules");
 	if (dbname == NULL) {
 		slog_debug(client, "routing_rules returned 'None' - existing connection preserved");
@@ -82,7 +82,7 @@ bool route_client_connection(PgSocket *client, int in_transaction, PktHdr *pkt) 
 		free(dbname);
 		return false;
 	}
-	pool = get_pool(db, client->login_user);
+	pool = get_pool(db, client->login_user_credentials);
 	if (client->pool != pool) {
 		if (client->link != NULL) {
 			/* release existing server connection back to pool */

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,14 +1,14 @@
 diff --git a/src/server.c b/src/server.c
-index 46db05a..f53d3b6 100644
+index 08e0211..5e9bf7e 100644
 --- a/src/server.c
 +++ b/src/server.c
-@@ -22,6 +22,44 @@
+@@ -27,6 +27,43 @@
  
- #include "bouncer.h"
+ #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
  
 +/*
-+* Returns the query data from the server. This must be freed.
-+*/
++ * Returns the query data from the server. This must be freed.
++ */
 +static char *query_data(PktHdr *pkt)
 +{
 +	uint16_t columns;
@@ -43,11 +43,10 @@ index 46db05a..f53d3b6 100644
 +	return output;
 +}
 +
-+
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -92,6 +130,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -120,6 +157,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	SBuf *sbuf = &server->sbuf;
  	bool res = false;
  	const uint8_t *ckey;
@@ -56,7 +55,7 @@ index 46db05a..f53d3b6 100644
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -102,11 +142,15 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -130,11 +169,15 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	if (server->exec_on_connect) {
  		switch (pkt->type) {
  		case 'Z':
@@ -69,10 +68,10 @@ index 46db05a..f53d3b6 100644
 +			// require topology table to exist in the cluster if using
 +			if (fast_switchover)
 +				fatal("does the topology table exist?");
- 			/* fallthrough */
+ 		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -120,6 +164,38 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -148,6 +191,38 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -109,9 +108,9 @@ index 46db05a..f53d3b6 100644
 +		return true;
 +		break;
  	case 'E':		/* ErrorResponse */
- 		if (!server->pool->welcome_msg_ready)
- 			kill_pool_logins_server_error(server->pool, pkt);
-@@ -152,8 +228,20 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 		/*
+ 		 * If we cannot log into the server, then we drop all clients
+@@ -195,8 +270,20 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -132,15 +131,15 @@ index 46db05a..f53d3b6 100644
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
  		server->ready = true;
-@@ -250,6 +338,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
- 	SBuf *sbuf = &server->sbuf;
- 	PgSocket *client = server->link;
+@@ -336,6 +423,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
+ 	struct List *item, *tmp;
+ 	bool ignore_packet = false;
 +	bool res = false;
  
  	Assert(!server->pool->db->admin);
  
-@@ -261,6 +350,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -347,6 +435,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case 'Z':		/* ReadyForQuery */
@@ -156,9 +155,9 @@ index 46db05a..f53d3b6 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -318,6 +416,13 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
- 		}
- 		/* fallthrough */
+@@ -433,6 +530,13 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 		server->query_failed = true;
+ 		break;
  	case 'C':		/* CommandComplete */
 +		/*
 +		 * In the process of discarding topology data without sending to the client.
@@ -170,7 +169,7 @@ index 46db05a..f53d3b6 100644
  
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
-@@ -358,6 +463,29 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -518,6 +622,29 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case 'd':		/* CopyData(F/B) */
  	case 'D':		/* DataRow */
@@ -197,18 +196,19 @@ index 46db05a..f53d3b6 100644
 +			server->pool->checking_for_new_writer = false;
 +			free(data);
 +		}
- 	case 't':		/* ParameterDescription */
- 	case 'T':		/* RowDescription */
  		break;
-@@ -418,13 +546,26 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 	}
+ 	server->idle_tx = idle_tx;
+@@ -605,14 +732,26 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
--		if (server->state != SV_TESTED)
+-		if (server->state != SV_TESTED) {
 +		if (server->state != SV_TESTED && !server->pool->db->topology_query)
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
+-		}
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -228,7 +228,7 @@ index 46db05a..f53d3b6 100644
  	return true;
  }
  
-@@ -538,6 +679,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -727,6 +866,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -236,7 +236,7 @@ index 46db05a..f53d3b6 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -552,8 +694,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -741,8 +881,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -256,7 +256,7 @@ index 46db05a..f53d3b6 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -593,6 +745,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -783,6 +933,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);

--- a/src/util.c.diff
+++ b/src/util.c.diff
@@ -1,10 +1,10 @@
 diff --git a/src/util.c b/src/util.c
-index 10bd2c3..6940c29 100644
+index df6ae66..a927d0c 100644
 --- a/src/util.c
 +++ b/src/util.c
-@@ -26,6 +26,33 @@
- #include <usual/crypto/csrandom.h>
- #include <usual/socket.h>
+@@ -32,6 +32,33 @@
+ #include <openssl/evp.h>
+ #endif
  
 +PgPool *get_global_writer(PgPool *pool)
 +{


### PR DESCRIPTION
*Issue #, if available:*
#87 

*Description of changes:*
Reapplies the pgbouncer-fast-switchover patch on top of the current stable 1.23 pgbouncer release (1.23.1). The most notable motivation for upgrading is that pgbouncer 1.21 and later has prepared statements support.

The following problem must be corrected:
When specifying `user` for a database, `parse_database` triggers a crash because of the changes introduced in 8056484c816899fc97f2f3a3f2dff1ff11393ddf. Since 1.20, a varcache system has been implemented which only gets initialized in `init_caches`, but because `parse_database` is called prior to that, it can trigger a null pointer deference for `var_list_cache` in `new_pool`. Reordering `init_caches` to come before `load_config` causes its own set of problems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
