### PR TITLE
Fast switch over support for Blue Green Deployment

### DIFF
--- a/doc/config.md.diff
+++ b/doc/config.md.diff
@@ -1,8 +1,8 @@
 diff --git a/doc/config.md b/doc/config.md
-index b181730..4872044 100644
+index 70c720f..eb0b279 100644
 --- a/doc/config.md
 +++ b/doc/config.md
-@@ -131,6 +131,28 @@ the per-database configuration.
+@@ -131,6 +131,35 @@ the per-database configuration.
  
  Default: 20
  
@@ -20,6 +20,13 @@ index b181730..4872044 100644
 +
 +Default: 30
 +
++### topology_monitoring_interval
++
++How often (in seconds) the system runs a topology check to monitor metadata status during a
++Blue-Green deployment, when fast switchover is enabled.
++
++Default: 60
++
 +### recreate_disconnected_pools
 +
 +If enabled, and [topology_query](#topology_query) is set for a pool, connections to the pools
@@ -31,7 +38,7 @@ index b181730..4872044 100644
  ### min_pool_size
  
  Add more server connections to pool if below this number.
-@@ -1055,6 +1077,13 @@ Query to be executed after a connection is established, but before
+@@ -1257,6 +1286,13 @@ Query to be executed after a connection is established, but before
  allowing the connection to be used by any clients. If the query raises errors,
  they are logged but ignored otherwise.
  

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index d607ddc..974dd8a 100644
+index d607ddc..39e4282 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
 @@ -144,6 +144,22 @@ enum LoadBalanceHosts {
@@ -41,7 +41,7 @@ index d607ddc..974dd8a 100644
  #include "util.h"
  #include "iobuf.h"
  #include "sbuf.h"
-@@ -302,6 +324,16 @@ const char *pga_str(const PgAddr *a, char *dst, int dstlen);
+@@ -302,6 +324,25 @@ const char *pga_str(const PgAddr *a, char *dst, int dstlen);
  const char *pga_details(const PgAddr *a, char *dst, int dstlen);
  int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
  
@@ -55,10 +55,19 @@ index d607ddc..974dd8a 100644
 +	char *status;     // Operational status (e.g., AVAILABLE, SWITCHOVER_IN_POST_PROCESSING, SWITCHOVER_COMPLETED)
 +};
 +
++/*
++ * Structure representing failed pool list due to connection failure
++ */
++struct FailedPgPool {
++	struct List head;  // list node
++	PgPool *pool;      // pointer to the failed PgPool
++};
++
++
  /*
   * Stats, kept per-pool.
   */
-@@ -448,13 +480,33 @@ struct PgPool {
+@@ -448,13 +489,33 @@ struct PgPool {
  
  	/* if last connect to server failed, there should be delay before next */
  	usec_t last_connect_time;
@@ -92,7 +101,7 @@ index d607ddc..974dd8a 100644
  };
  
  /*
-@@ -564,6 +616,8 @@ struct PgDatabase {
+@@ -564,6 +625,8 @@ struct PgDatabase {
  	int max_db_connections;	/* max server connections between all pools */
  	usec_t server_lifetime;	/* max lifetime of server connection */
  	char *connect_query;	/* startup commands to send to server after connect */
@@ -101,7 +110,7 @@ index d607ddc..974dd8a 100644
  	enum LoadBalanceHosts load_balance_hosts;	/* strategy for host selection in a comma-separated host list */
  
  	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
-@@ -583,6 +637,9 @@ struct PgDatabase {
+@@ -583,6 +646,9 @@ struct PgDatabase {
  	bool db_disabled;	/* is the database accepting new connections? */
  	bool admin;		/* internal console db */
  	bool fake;		/* not a real database, only for mock auth */
@@ -111,7 +120,7 @@ index d607ddc..974dd8a 100644
  	usec_t inactive_time;	/* when auto-database became inactive (to kill it after timeout) */
  	unsigned active_stamp;	/* set if autodb has connections */
  	int connection_count;	/* total connections for this database in all pools */
-@@ -767,7 +824,9 @@ extern int cf_peer_id;
+@@ -767,7 +833,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -121,7 +130,7 @@ index d607ddc..974dd8a 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -786,6 +845,8 @@ extern int cf_server_reset_query_always;
+@@ -786,6 +854,8 @@ extern int cf_server_reset_query_always;
  extern char *cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
@@ -130,7 +139,7 @@ index d607ddc..974dd8a 100644
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -840,6 +901,11 @@ extern int cf_log_disconnections;
+@@ -840,6 +910,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index d607ddc..e47c2aa 100644
+index d607ddc..974dd8a 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
 @@ -144,6 +144,22 @@ enum LoadBalanceHosts {
@@ -101,16 +101,17 @@ index d607ddc..e47c2aa 100644
  	enum LoadBalanceHosts load_balance_hosts;	/* strategy for host selection in a comma-separated host list */
  
  	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
-@@ -583,6 +637,8 @@ struct PgDatabase {
+@@ -583,6 +637,9 @@ struct PgDatabase {
  	bool db_disabled;	/* is the database accepting new connections? */
  	bool admin;		/* internal console db */
  	bool fake;		/* not a real database, only for mock auth */
 +
 +	enum BlueGreenDeploymentDBType blue_green_deployment_db_type;	/* indicates the current database context in a Blue-Green deployment (e.g., DEFAULT, SOURCE, or TARGET) */
++	bool is_topology_check_in_progress; /* enables topology monitoring when fast switchover is active; used to track metadata state during Blue-Green deployment. */
  	usec_t inactive_time;	/* when auto-database became inactive (to kill it after timeout) */
  	unsigned active_stamp;	/* set if autodb has connections */
  	int connection_count;	/* total connections for this database in all pools */
-@@ -767,7 +823,9 @@ extern int cf_peer_id;
+@@ -767,7 +824,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -120,15 +121,16 @@ index d607ddc..e47c2aa 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -786,6 +844,7 @@ extern int cf_server_reset_query_always;
+@@ -786,6 +845,8 @@ extern int cf_server_reset_query_always;
  extern char *cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
 +extern usec_t cf_server_failed_delay;
++extern usec_t cf_topology_monitoring_interval;
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -840,6 +899,11 @@ extern int cf_log_disconnections;
+@@ -840,6 +901,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index d607ddc..e6103b2 100644
+index d607ddc..e912b5e 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
 @@ -165,6 +165,11 @@ typedef enum ReplicationType ReplicationType;
@@ -57,7 +57,15 @@ index d607ddc..e6103b2 100644
  	enum LoadBalanceHosts load_balance_hosts;	/* strategy for host selection in a comma-separated host list */
  
  	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
-@@ -767,7 +794,9 @@ extern int cf_peer_id;
+@@ -583,6 +610,7 @@ struct PgDatabase {
+ 	bool db_disabled;	/* is the database accepting new connections? */
+ 	bool admin;		/* internal console db */
+ 	bool fake;		/* not a real database, only for mock auth */
++	bool is_source_db;      /* is this a source database of Blue Green Deployment */
+ 	usec_t inactive_time;	/* when auto-database became inactive (to kill it after timeout) */
+ 	unsigned active_stamp;	/* set if autodb has connections */
+ 	int connection_count;	/* total connections for this database in all pools */
+@@ -767,7 +795,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -67,7 +75,7 @@ index d607ddc..e6103b2 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -786,6 +815,7 @@ extern int cf_server_reset_query_always;
+@@ -786,6 +816,7 @@ extern int cf_server_reset_query_always;
  extern char *cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
@@ -75,7 +83,7 @@ index d607ddc..e6103b2 100644
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -840,6 +870,11 @@ extern int cf_log_disconnections;
+@@ -840,6 +871,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,8 +1,35 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index d607ddc..e912b5e 100644
+index d607ddc..e47c2aa 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
-@@ -165,6 +165,11 @@ typedef enum ReplicationType ReplicationType;
+@@ -144,6 +144,22 @@ enum LoadBalanceHosts {
+ 	LOAD_BALANCE_HOSTS_ROUND_ROBIN
+ };
+ 
++/**
++ * Enum representing different database contexts used during a Blue-Green deployment.
++ *
++ * - DEFAULT: Represents the default database (used in pgbouncer configuration).
++ * - BLUE_GREEN_SOURCE: The source database in a Blue-Green deployment (usually the current database).
++ * - BLUE_GREEN_TARGET: The target database in a Blue-Green deployment (usually the new database to switch to).
++ *
++ * Note: Initially DEFAULT and BLUE_GREEN_SOURCE typically point to the same database instance (i.e., the same IP address).
++ */
++
++enum BlueGreenDeploymentDBType {
++	DEFAULT,
++	BLUE_GREEN_SOURCE,
++	BLUE_GREEN_TARGET
++};
++
+ #define is_server_socket(sk) ((sk)->state >= SV_FREE)
+ 
+ 
+@@ -162,9 +178,15 @@ typedef struct ScramState ScramState;
+ typedef struct PgPreparedStatement PgPreparedStatement;
+ typedef enum ResponseAction ResponseAction;
+ typedef enum ReplicationType ReplicationType;
++typedef struct TopologyData TopologyData;
  
  extern int cf_sbuf_len;
  
@@ -14,7 +41,24 @@ index d607ddc..e912b5e 100644
  #include "util.h"
  #include "iobuf.h"
  #include "sbuf.h"
-@@ -448,13 +453,33 @@ struct PgPool {
+@@ -302,6 +324,16 @@ const char *pga_str(const PgAddr *a, char *dst, int dstlen);
+ const char *pga_details(const PgAddr *a, char *dst, int dstlen);
+ int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
+ 
++/*
++ * Structure representing parsed topology information for a database instance
++ */
++struct TopologyData {
++	char *endpoint;   // Hostname or IP address of the instance
++	char *role;       // Role of the instance (e.g., BLUE_GREEN_DEPLOYMENT_SOURCE, BLUE_GREEN_DEPLOYMENT_TARGET)
++	int port_num;     // Port number the instance is listening on
++	char *status;     // Operational status (e.g., AVAILABLE, SWITCHOVER_IN_POST_PROCESSING, SWITCHOVER_COMPLETED)
++};
++
+ /*
+  * Stats, kept per-pool.
+  */
+@@ -448,13 +480,33 @@ struct PgPool {
  
  	/* if last connect to server failed, there should be delay before next */
  	usec_t last_connect_time;
@@ -48,7 +92,7 @@ index d607ddc..e912b5e 100644
  };
  
  /*
-@@ -564,6 +589,8 @@ struct PgDatabase {
+@@ -564,6 +616,8 @@ struct PgDatabase {
  	int max_db_connections;	/* max server connections between all pools */
  	usec_t server_lifetime;	/* max lifetime of server connection */
  	char *connect_query;	/* startup commands to send to server after connect */
@@ -57,15 +101,16 @@ index d607ddc..e912b5e 100644
  	enum LoadBalanceHosts load_balance_hosts;	/* strategy for host selection in a comma-separated host list */
  
  	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
-@@ -583,6 +610,7 @@ struct PgDatabase {
+@@ -583,6 +637,8 @@ struct PgDatabase {
  	bool db_disabled;	/* is the database accepting new connections? */
  	bool admin;		/* internal console db */
  	bool fake;		/* not a real database, only for mock auth */
-+	bool is_source_db;      /* is this a source database of Blue Green Deployment */
++
++	enum BlueGreenDeploymentDBType blue_green_deployment_db_type;	/* indicates the current database context in a Blue-Green deployment (e.g., DEFAULT, SOURCE, or TARGET) */
  	usec_t inactive_time;	/* when auto-database became inactive (to kill it after timeout) */
  	unsigned active_stamp;	/* set if autodb has connections */
  	int connection_count;	/* total connections for this database in all pools */
-@@ -767,7 +795,9 @@ extern int cf_peer_id;
+@@ -767,7 +823,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -75,7 +120,7 @@ index d607ddc..e912b5e 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -786,6 +816,7 @@ extern int cf_server_reset_query_always;
+@@ -786,6 +844,7 @@ extern int cf_server_reset_query_always;
  extern char *cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
@@ -83,7 +128,7 @@ index d607ddc..e912b5e 100644
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -840,6 +871,11 @@ extern int cf_log_disconnections;
+@@ -840,6 +899,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index fccedc5..36b5e11 100644
+index d607ddc..e6103b2 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
 @@ -165,6 +165,11 @@ typedef enum ReplicationType ReplicationType;
@@ -14,18 +14,18 @@ index fccedc5..36b5e11 100644
  #include "util.h"
  #include "iobuf.h"
  #include "sbuf.h"
-@@ -455,13 +460,33 @@ struct PgPool {
+@@ -448,13 +453,33 @@ struct PgPool {
  
  	/* if last connect to server failed, there should be delay before next */
  	usec_t last_connect_time;
 +	usec_t last_poll_time;
 +	usec_t last_failed_time; // last time the connection failed
-	bool last_connect_failed : 1;
-	char last_connect_failed_message[100];
-	bool last_login_failed : 1;
-
-	bool welcome_msg_ready : 1;
-
+ 	bool last_connect_failed : 1;
+ 	char last_connect_failed_message[100];
+ 	bool last_login_failed : 1;
+ 
+ 	bool welcome_msg_ready : 1;
+ 
 +	bool recently_checked : 1; // should be set once checking starts. If all pools have this set, they need to be unset so we can loop again.
 +	bool initial_writer_endpoint : 1; // used to indicate a configured writer when starting PgBouncer. Used for getting the topology of the cluster associated with the writer.
 +	bool refresh_topology : 1; // after a new writer is found, indicate that we need to refresh the topology.
@@ -42,21 +42,22 @@ index fccedc5..36b5e11 100644
 +
 +	uint16_t num_nodes;
 +
-	uint16_t rrcounter;		/* round-robin counter */
+ 	uint16_t rrcounter;		/* round-robin counter */
 +	PgPool *global_writer;	/* global_writer pool for this pool */;
 +	PgPool *parent_pool;	/* the parent pool for setting the global writer */
  };
  
  /*
-@@ -572,6 +597,7 @@ struct PgDatabase {
+@@ -564,6 +589,8 @@ struct PgDatabase {
  	int max_db_connections;	/* max server connections between all pools */
-	usec_t server_lifetime;	/* max lifetime of server connection */
+ 	usec_t server_lifetime;	/* max lifetime of server connection */
  	char *connect_query;	/* startup commands to send to server after connect */
 +	char *topology_query;	/* command to get topology to determine promoted writer. Also used to indicate whether to use fast_switchovers on a specific node */
-	enum LoadBalanceHosts load_balance_hosts;	/* strategy for host selection in a comma-separated host list */
-
-	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
-@@ -783,7 +809,9 @@ extern int cf_peer_id;
++	char *recovery_query;   /* command to get status of Blue Green Deployement to determine the new writer. This recovery query is given by the user */
+ 	enum LoadBalanceHosts load_balance_hosts;	/* strategy for host selection in a comma-separated host list */
+ 
+ 	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
+@@ -767,7 +794,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -66,15 +67,15 @@ index fccedc5..36b5e11 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -803,6 +831,7 @@ extern char *cf_server_check_query;
- extern bool empty_server_check_query;
+@@ -786,6 +815,7 @@ extern int cf_server_reset_query_always;
+ extern char *cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
 +extern usec_t cf_server_failed_delay;
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -859,6 +888,11 @@ extern int cf_log_disconnections;
+@@ -840,6 +870,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/loader.h.diff
+++ b/include/loader.h.diff
@@ -1,10 +1,13 @@
 diff --git a/include/loader.h b/include/loader.h
-index 1acbefe..ddb044f 100644
+index 1acbefe..07f7305 100644
 --- a/include/loader.h
 +++ b/include/loader.h
-@@ -25,3 +25,5 @@ bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
+@@ -25,3 +25,8 @@ bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
  /* user file parsing */
  bool load_auth_file(const char *fn) /* _MUSTCHECK */;
  bool loader_users_check(void) /* _MUSTCHECK */;
 +
-+PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname);
++/*
++ * Initializes and returns a new connection pool for the specified database, host, and port.
++ */
++PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname, int port);

--- a/include/objects.h.diff
+++ b/include/objects.h.diff
@@ -1,18 +1,25 @@
 diff --git a/include/objects.h b/include/objects.h
-index 0b498dd..732dab3 100644
+index 0b498dd..1f014df 100644
 --- a/include/objects.h
 +++ b/include/objects.h
-@@ -37,6 +37,13 @@ extern struct Slab *outstanding_request_cache;
+@@ -37,6 +37,20 @@ extern struct Slab *outstanding_request_cache;
  extern struct Slab *var_list_cache;
  extern struct Slab *server_prepared_statement_cache;
  extern PgPreparedStatement *prepared_statements;
 +extern bool fast_switchover;
++extern bool is_topology_monitoring_job_enabled;
 +/* Stores the new port number set by customer for the green (target) instance during Blue-Green Deployment fast switchover. */
 +extern int updated_target_port_num;
 +/* Tracks whether traffic has been successfully routed to the green (target) instance during Blue Green Deployment fast switchover. */
 +extern bool routing_traffic_to_target_complete;
-+/* Store the database info from PgBouncer config to support fast switchover. */
-+extern PgDatabase *fast_switchover_db;
++/* Tracks if the source instance was down before the switchover. */
++extern bool source_instance_down_before_switchover;
++/* Store the database info from PgBouncer config to support fast switchovers. */
++extern PgDatabase **fast_switchover_db;
++/* Stores the count of database configurations used for fast switchover */
++extern int fast_switchover_configured_db_count;
++/* Current allocated capacity of the fast_switchover_db array (in number of entries). */
++extern int fast_switchover_db_capacity;
  
  extern unsigned long long int last_pgsocket_id;
  

--- a/include/objects.h.diff
+++ b/include/objects.h.diff
@@ -1,14 +1,18 @@
 diff --git a/include/objects.h b/include/objects.h
-index 0b498dd..7fe471d 100644
+index 0b498dd..732dab3 100644
 --- a/include/objects.h
 +++ b/include/objects.h
-@@ -37,6 +37,9 @@ extern struct Slab *outstanding_request_cache;
+@@ -37,6 +37,13 @@ extern struct Slab *outstanding_request_cache;
  extern struct Slab *var_list_cache;
  extern struct Slab *server_prepared_statement_cache;
  extern PgPreparedStatement *prepared_statements;
 +extern bool fast_switchover;
++/* Stores the new port number set by customer for the green (target) instance during Blue-Green Deployment fast switchover. */
++extern int updated_target_port_num;
++/* Tracks whether traffic has been successfully routed to the green (target) instance during Blue Green Deployment fast switchover. */
++extern bool routing_traffic_to_target_complete;
 +/* Store the database info from PgBouncer config to support fast switchover. */
 +extern PgDatabase *fast_switchover_db;
-
+ 
  extern unsigned long long int last_pgsocket_id;
  

--- a/include/server.h.diff
+++ b/include/server.h.diff
@@ -1,14 +1,15 @@
 diff --git a/include/server.h b/include/server.h
-index e500b11..03c3fae 100644
+index e500b11..8bd9eab 100644
 --- a/include/server.h
 +++ b/include/server.h
-@@ -16,6 +16,10 @@
+@@ -16,6 +16,11 @@
   * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   */
  
 +/* Define constants that indicate the switchover status in a Blue-Green Deployment */
 +#define SWITCHOVER_IN_POST_PROCESSING "SWITCHOVER_IN_POST_PROCESSING"
 +#define SWITCHOVER_COMPLETED "SWITCHOVER_COMPLETED"
++#define BLUE_GREEN_DEPLOYMENT_SOURCE "BLUE_GREEN_DEPLOYMENT_SOURCE"
 +
  bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
  void kill_pool_logins(PgPool *pool, const char *sqlstate, const char *msg);

--- a/include/server.h.diff
+++ b/include/server.h.diff
@@ -1,0 +1,15 @@
+diff --git a/include/server.h b/include/server.h
+index e500b11..03c3fae 100644
+--- a/include/server.h
++++ b/include/server.h
+@@ -16,6 +16,10 @@
+  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++/* Define constants that indicate the switchover status in a Blue-Green Deployment */
++#define SWITCHOVER_IN_POST_PROCESSING "SWITCHOVER_IN_POST_PROCESSING"
++#define SWITCHOVER_COMPLETED "SWITCHOVER_COMPLETED"
++
+ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
+ void kill_pool_logins(PgPool *pool, const char *sqlstate, const char *msg);
+ const char * kill_pool_logins_server_error(PgPool *pool, PktHdr *errpkt);

--- a/include/server.h.diff
+++ b/include/server.h.diff
@@ -1,8 +1,8 @@
 diff --git a/include/server.h b/include/server.h
-index e500b11..160654e 100644
+index e500b11..23aec0c 100644
 --- a/include/server.h
 +++ b/include/server.h
-@@ -16,6 +16,12 @@
+@@ -16,6 +16,13 @@
   * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   */
  
@@ -10,6 +10,7 @@ index e500b11..160654e 100644
 +#define SWITCHOVER_IN_POST_PROCESSING "SWITCHOVER_IN_POST_PROCESSING"
 +#define SWITCHOVER_COMPLETED "SWITCHOVER_COMPLETED"
 +#define BLUE_GREEN_DEPLOYMENT_SOURCE "BLUE_GREEN_DEPLOYMENT_SOURCE"
++#define BLUE_GREEN_DEPLOYMENT_TARGET "BLUE_GREEN_DEPLOYMENT_TARGET"
 +#define AVAILABLE "AVAILABLE"
 +
  bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;

--- a/include/server.h.diff
+++ b/include/server.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/server.h b/include/server.h
-index e500b11..23aec0c 100644
+index e500b11..43c49ce 100644
 --- a/include/server.h
 +++ b/include/server.h
 @@ -16,6 +16,13 @@
@@ -16,3 +16,13 @@ index e500b11..23aec0c 100644
  bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
  void kill_pool_logins(PgPool *pool, const char *sqlstate, const char *msg);
  const char * kill_pool_logins_server_error(PgPool *pool, PktHdr *errpkt);
+@@ -30,3 +37,9 @@ int database_max_connections(PgDatabase *db) _MUSTCHECK;
+ int database_max_client_connections(PgDatabase *db) _MUSTCHECK;
+ int user_max_connections(PgGlobalUser *user) _MUSTCHECK;
+ int user_client_max_connections(PgGlobalUser *user) _MUSTCHECK;
++/* Set up a new connection pool based on topology data. */
++PgPool* setup_new_pool(PgSocket *server, TopologyData *topology);
++/* Parse and validate topology data from a query result. */
++const char* parse_topology_data(PgSocket *server, char *data, TopologyData **topology_out);
++void cleanup_parsing_data_and_exit(TopologyData *topology, char *data_copy, char *port_str);
++void cleanup_topology(TopologyData *topology);

--- a/include/server.h.diff
+++ b/include/server.h.diff
@@ -1,8 +1,8 @@
 diff --git a/include/server.h b/include/server.h
-index e500b11..8bd9eab 100644
+index e500b11..160654e 100644
 --- a/include/server.h
 +++ b/include/server.h
-@@ -16,6 +16,11 @@
+@@ -16,6 +16,12 @@
   * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   */
  
@@ -10,6 +10,7 @@ index e500b11..8bd9eab 100644
 +#define SWITCHOVER_IN_POST_PROCESSING "SWITCHOVER_IN_POST_PROCESSING"
 +#define SWITCHOVER_COMPLETED "SWITCHOVER_COMPLETED"
 +#define BLUE_GREEN_DEPLOYMENT_SOURCE "BLUE_GREEN_DEPLOYMENT_SOURCE"
++#define AVAILABLE "AVAILABLE"
 +
  bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
  void kill_pool_logins(PgPool *pool, const char *sqlstate, const char *msg);

--- a/include/server.h.diff
+++ b/include/server.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/server.h b/include/server.h
-index e500b11..43c49ce 100644
+index e500b11..b415184 100644
 --- a/include/server.h
 +++ b/include/server.h
 @@ -16,6 +16,13 @@
@@ -21,7 +21,7 @@ index e500b11..43c49ce 100644
  int user_max_connections(PgGlobalUser *user) _MUSTCHECK;
  int user_client_max_connections(PgGlobalUser *user) _MUSTCHECK;
 +/* Set up a new connection pool based on topology data. */
-+PgPool* setup_new_pool(PgSocket *server, TopologyData *topology);
++PgPool* setup_new_pool(PgSocket *server, TopologyData *topology, bool is_replacement_pool);
 +/* Parse and validate topology data from a query result. */
 +const char* parse_topology_data(PgSocket *server, char *data, TopologyData **topology_out);
 +void cleanup_parsing_data_and_exit(TopologyData *topology, char *data_copy, char *port_str);

--- a/include/server.h.diff
+++ b/include/server.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/server.h b/include/server.h
-index e500b11..b415184 100644
+index e500b11..db428f4 100644
 --- a/include/server.h
 +++ b/include/server.h
 @@ -16,6 +16,13 @@
@@ -21,7 +21,7 @@ index e500b11..b415184 100644
  int user_max_connections(PgGlobalUser *user) _MUSTCHECK;
  int user_client_max_connections(PgGlobalUser *user) _MUSTCHECK;
 +/* Set up a new connection pool based on topology data. */
-+PgPool* setup_new_pool(PgSocket *server, TopologyData *topology, bool is_replacement_pool);
++PgPool* setup_new_pool(PgPool *pool_to_configure, TopologyData *topology);
 +/* Parse and validate topology data from a query result. */
 +const char* parse_topology_data(PgSocket *server, char *data, TopologyData **topology_out);
 +void cleanup_parsing_data_and_exit(TopologyData *topology, char *data_copy, char *port_str);

--- a/include/util.h.diff
+++ b/include/util.h.diff
@@ -1,10 +1,10 @@
 diff --git a/include/util.h b/include/util.h
-index 35a284b..32e9782 100644
+index f46e452..3c2d6ae 100644
 --- a/include/util.h
 +++ b/include/util.h
-@@ -19,6 +19,16 @@
- #include <usual/logging.h>
+@@ -20,6 +20,24 @@
  #include <usual/string.h>
+ #include <usual/cfparser.h>
  
 +/*
 + * sets the global writer to NULL for the pool
@@ -15,6 +15,14 @@ index 35a284b..32e9782 100644
 + * get the global writer, if any from the pool
 + */
 +PgPool *get_global_writer(PgPool *pool);
++
++/*
++ * checks if fast switchover mode is disabled for the specific pool.
++ * Fast switchover is enabled only when:
++ * 1. Pool has topology query configured and
++ * 2. fast switchover flag is enabled
++ */
++bool is_fast_switchover_disabled_for_pool(PgPool *pool);
 +
  /*
   * logging about specific socket

--- a/include/util.h.diff
+++ b/include/util.h.diff
@@ -1,11 +1,27 @@
 diff --git a/include/util.h b/include/util.h
-index f46e452..3c2d6ae 100644
+index f46e452..e052c39 100644
 --- a/include/util.h
 +++ b/include/util.h
-@@ -20,6 +20,24 @@
+@@ -20,6 +20,66 @@
  #include <usual/string.h>
  #include <usual/cfparser.h>
  
++// Define constants for cluster patterns
++#define CLUSTER_PREFIX       "cluster"
++#define CLUSTER_DASH_PREFIX  "cluster-"
++#define CLUSTER_RO_PREFIX    "cluster-ro-"
++#define CLUSTER_RO          "cluster-ro"
++#define CLUSTER_CUSTOM      "cluster-custom"
++#define CLUSTER_GREEN_TAG   "-green-"
++#define MAX_ENDPOINT_LENGTH 1024
++
++typedef enum {
++    HOST_CLUSTER_ENDPOINT_TYPE_NONE,
++    HOST_CLUSTER_ENDPOINT_TYPE_WRITER,
++    HOST_CLUSTER_ENDPOINT_TYPE_READER_ONLY,
++    HOST_CLUSTER_ENDPOINT_TYPE_CUSTOM
++} HostClusterEndPointType;
++
 +/*
 + * sets the global writer to NULL for the pool
 + */
@@ -23,6 +39,32 @@ index f46e452..3c2d6ae 100644
 + * 2. fast switchover flag is enabled
 + */
 +bool is_fast_switchover_disabled_for_pool(PgPool *pool);
++
++/*
++ * Determine the type of cluster endpoint (reader, writer, or custom) configured by the customer.
++ * Based on the type, create a connection pool for the corresponding endpoint on the target cluster:
++ *   - If the customer has configured a read-only endpoint, create a pool for the read endpoint of the target cluster.
++ *   - If the customer has configured a writer endpoint, create a pool for the writer endpoint of the target cluster.
++ *   - If it is a custom endpoint, create a pool for the corresponding custom endpoint of the target cluster.
++ */
++bool setup_connection_pool_based_on_endpoint_type(char *hostName, char *endpoint);
++
++/*
++ * If the connection is established through the cluster reader endpoint,
++ * append the 'ro' suffix to the endpoint string to form the target read-only endpoint
++ * before establishing the connection in the pool.
++ */
++bool append_ro_suffix_to_cluster_reader_endpoint(char* endpoint, size_t endpoint_size);
++
++/*
++ * Determines whether the given endpoint belong to a cluster Host.
++ */
++bool is_cluster_endpoint(char* endpoint);
++
++/*
++ * Splits the given endpoint string into database name and DNS name components.
++ */
++bool split_dbname_and_dnsname(char *endpoint, char **db_name, char **dns_name);
 +
  /*
   * logging about specific socket

--- a/include/util.h.diff
+++ b/include/util.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/util.h b/include/util.h
-index f46e452..84e91fd 100644
+index f46e452..a3a3cb2 100644
 --- a/include/util.h
 +++ b/include/util.h
 @@ -20,6 +20,66 @@
@@ -69,3 +69,9 @@ index f46e452..84e91fd 100644
  /*
   * logging about specific socket
   */
+@@ -70,3 +130,5 @@ bool cf_set_authdb(struct CfValue *cv, const char *value);
+ 
+ /* reserved database name checking */
+ bool check_reserved_database(const char *value);
++/* concat_multiple_strings - Concatenates multiple strings into a single dynamically allocated string */
++char *concat_multiple_strings(int count, ...);

--- a/include/util.h.diff
+++ b/include/util.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/util.h b/include/util.h
-index f46e452..e052c39 100644
+index f46e452..84e91fd 100644
 --- a/include/util.h
 +++ b/include/util.h
 @@ -20,6 +20,66 @@
@@ -47,14 +47,14 @@ index f46e452..e052c39 100644
 + *   - If the customer has configured a writer endpoint, create a pool for the writer endpoint of the target cluster.
 + *   - If it is a custom endpoint, create a pool for the corresponding custom endpoint of the target cluster.
 + */
-+bool setup_connection_pool_based_on_endpoint_type(char *hostName, char *endpoint);
++bool setup_connection_pool_based_on_endpoint_type(char *hostName, char **endpoint);
 +
 +/*
 + * If the connection is established through the cluster reader endpoint,
 + * append the 'ro' suffix to the endpoint string to form the target read-only endpoint
 + * before establishing the connection in the pool.
 + */
-+bool append_ro_suffix_to_cluster_reader_endpoint(char* endpoint, size_t endpoint_size);
++bool append_ro_suffix_to_cluster_reader_endpoint(char** endpoint, size_t endpoint_size);
 +
 +/*
 + * Determines whether the given endpoint belong to a cluster Host.

--- a/install-pgbouncer-rr-patch.sh
+++ b/install-pgbouncer-rr-patch.sh
@@ -39,6 +39,7 @@ MERGEFILES="\
    include/objects.h\
    include/pktbuf.h\
    include/util.h\
+   include/server.h\
    src/admin.c\
    src/janitor.c\
    src/loader.c\

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 5131ea5..edd6b7f 100644
+index 5131ea5..730ad7e 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
 @@ -24,9 +24,16 @@
@@ -336,15 +336,7 @@ index 5131ea5..edd6b7f 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -325,17 +581,48 @@ void per_loop_maint(void)
- 			force_suspend = true;
- 	}
- 
-+	if (fast_switchover && (routing_traffic_to_target_complete || source_instance_down_before_switchover)) {
-+		reset_blue_green_switchover_flags();
-+	}
-+
- 	statlist_for_each(item, &pool_list) {
+@@ -329,13 +585,48 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -355,18 +347,26 @@ index 5131ea5..edd6b7f 100644
 +
 +			pool->initial_writer_endpoint = true;
 +			log_debug("create initial pool during startup for: %s", pool->db->name);
++		} else if (fast_switchover && pool->db->recovery_query != NULL && pool->last_connect_failed) {
++			if (source_instance_down_before_switchover) {
++				log_debug("last connect failed: %s, so launching new connection in per_loop_maint", pool->db->name);
++				launch_new_connection(pool, true);
++			} else if (routing_traffic_to_target_complete) {
++				log_debug("post switchover due to dns change connection closed: %s, so launching new connection in per_loop_maint", pool->db->name);
++				if (updated_target_port_num !=0 && updated_target_port_num != pool->db->port) {
++					/*
++					 * We are here because the customer changed the green instance's port before the switchover.
++					 * Since traffic has now switched to the new target (which was previously green),
++					 * we need to update the pool's port to the new value before attempting a connection.
++					 */
++					pool->db->port = updated_target_port_num;
++				}
++				launch_new_connection(pool, true);
++			}
 +		} else {
 +			if (fast_switchover && pool->last_connect_failed && get_global_writer(pool)) {
 +				if (now - pool->last_failed_time > cf_server_failed_delay) {
 +					log_debug("last connect failed: %s, so launching new connection in per_loop_maint", pool->db->name);
-+					if (routing_traffic_to_target_complete && updated_target_port_num !=0 && updated_target_port_num != pool->db->port) {
-+						/*
-+						 * We are here because the customer changed the green instance's port before the switchover.
-+						 * Since traffic has now switched to the new target (which was previously green),
-+						 * we need to update the pool's port to the new value before attempting a connection.
-+						 */
-+						pool->db->port = updated_target_port_num;
-+					}
 +					launch_new_connection(pool, true);
 +				}
 +			}
@@ -386,7 +386,23 @@ index 5131ea5..edd6b7f 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -374,6 +661,174 @@ void per_loop_maint(void)
+@@ -352,6 +643,15 @@ void per_loop_maint(void)
+ 		}
+ 	}
+ 
++	/*
++	 * These flags (routing_traffic_to_target_complete and
++	 * source_instance_down_before_switchover) are set to true
++	 * only during a blue-green deployment.
++	 */
++	if (fast_switchover && (source_instance_down_before_switchover || routing_traffic_to_target_complete)) {
++		reset_blue_green_switchover_flags();
++	}
++
+ 	switch (cf_pause_mode) {
+ 	case P_SUSPEND:
+ 		if (force_suspend) {
+@@ -374,6 +674,174 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -561,7 +577,7 @@ index 5131ea5..edd6b7f 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -494,6 +949,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -494,6 +962,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
@@ -569,7 +585,7 @@ index 5131ea5..edd6b7f 100644
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
  		} else if (age >= server_lifetime) {
-@@ -877,6 +1333,8 @@ void kill_database(PgDatabase *db)
+@@ -877,6 +1346,8 @@ void kill_database(PgDatabase *db)
  	if (db->forced_user_credentials)
  		slab_free(credentials_cache, db->forced_user_credentials);
  	free(db->connect_query);

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,8 +1,8 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 5131ea5..c39e84c 100644
+index 5131ea5..0c93e5a 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
-@@ -24,6 +24,8 @@
+@@ -24,9 +24,15 @@
  
  #include <usual/slab.h>
  
@@ -11,7 +11,14 @@ index 5131ea5..c39e84c 100644
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
  static struct event full_maint_ev;
-@@ -127,21 +129,159 @@ void resume_all(void)
++/* Event used to periodically check Blue-Green topology status */
++static struct event blue_green_topology_check_ev;
++/* Time interval for Blue-Green topology monitoring */
++static struct timeval blue_green_topology_monitoring_interval;
+ extern bool any_user_level_server_timeout_set;
+ extern bool any_user_level_client_timeout_set;
+ 
+@@ -127,21 +133,159 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -177,7 +184,7 @@ index 5131ea5..c39e84c 100644
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -156,6 +296,36 @@ static void launch_recheck(PgPool *pool)
+@@ -156,6 +300,36 @@ static void launch_recheck(PgPool *pool)
  			need_check = false;
  	}
  
@@ -214,7 +221,7 @@ index 5131ea5..c39e84c 100644
  	if (need_check) {
  		/* send test query, wait for result */
  		slog_debug(server, "P: checking: %s", q);
-@@ -210,11 +380,22 @@ static void per_loop_activate(PgPool *pool)
+@@ -210,11 +384,22 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -239,7 +246,7 @@ index 5131ea5..c39e84c 100644
  			break;
  		}
  	}
-@@ -306,10 +487,7 @@ static int per_loop_wait_close(PgPool *pool)
+@@ -306,10 +491,7 @@ static int per_loop_wait_close(PgPool *pool)
  	return count;
  }
  
@@ -251,7 +258,7 @@ index 5131ea5..c39e84c 100644
  {
  	struct List *item;
  	PgPool *pool;
-@@ -318,6 +496,7 @@ void per_loop_maint(void)
+@@ -318,6 +500,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -259,7 +266,7 @@ index 5131ea5..c39e84c 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -329,13 +508,32 @@ void per_loop_maint(void)
+@@ -329,13 +512,40 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -274,6 +281,14 @@ index 5131ea5..c39e84c 100644
 +			if (fast_switchover && pool->last_connect_failed && get_global_writer(pool)) {
 +				if (now - pool->last_failed_time > cf_server_failed_delay) {
 +					log_debug("last connect failed: %s, so launching new connection in per_loop_maint", pool->db->name);
++					if (routing_traffic_to_target_complete && updated_target_port_num !=0 && updated_target_port_num != pool->db->port) {
++						/*
++						 * We are here because the customer changed the green instance's port before the switchover.
++						 * Since traffic has now switched to the new target (which was previously green),
++						 * we need to update the pool's port to the new value before attempting a connection.
++						 */
++						pool->db->port = updated_target_port_num;
++					}
 +					launch_new_connection(pool, true);
 +				}
 +			}
@@ -293,10 +308,117 @@ index 5131ea5..c39e84c 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -374,6 +572,37 @@ void per_loop_maint(void)
+@@ -374,6 +584,148 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
++/**
++ * @brief Executes topology query on Blue-Green source instance to monitor deployment status.
++ *
++ * This event callback function performs topology checks by:
++ * - Finding the source (blue) instance in the pool list
++ * - Running topology query on an available server connection
++ * - Using either idle or active server connections
++ *
++ * Checks are skipped if:
++ * - Fast switchover is disabled (also removes event)
++ * - A check is already running (prevents concurrent execution)
++ * - Pool has no topology or recovery query configured
++ * - Pool is not a Blue-Green source instance
++ * - No server connections are available
++ *
++ * @note Sets is_topology_check_in_progress flag before executing query
++ * @note Disconnects server if query send fails
++ */
++static void do_topology_check(evutil_socket_t sock, short flags, void *arg)
++{
++	struct List *item;
++	PgPool *pool;
++	PgSocket *server;
++	bool res = true;
++	static bool is_running = false;
++
++	if (!fast_switchover) {
++		event_del(&blue_green_topology_check_ev);
++		return;
++	}
++
++	/* Avoid running multiple checks simultaneously */
++	if (is_running)
++		return;
++
++	is_running = true;
++
++	/* Iterate through pools to find the global writer */
++	statlist_for_each(item, &pool_list) {
++		pool = container_of(item, PgPool, head);
++
++		if (!pool->db->topology_query || pool->db->admin)
++			continue;
++
++		if (pool->db->blue_green_deployment_db_type != BLUE_GREEN_SOURCE)
++			continue;
++
++		/* Found BLUE_GREEN_SOURCE pool, now get an available server */
++		server = first_socket(&pool->idle_server_list);
++		if (!server)
++			server = first_socket(&pool->used_server_list);
++
++		if (!server || !server->ready) {
++			log_debug("topology_check: no available server in pool");
++			continue;
++		}
++
++		if (server->pool->db->is_topology_check_in_progress)
++			continue;
++
++		server->pool->db->is_topology_check_in_progress = true;
++		/* Send topology query */
++		slog_debug(server, "topology_check: executing: %s", pool->db->topology_query);
++		SEND_generic(res, server, PqMsg_Query, "s", pool->db->topology_query);
++		if (!res)
++			disconnect_server(server, false, "topology query failed");
++
++		break;
++	}
++
++	is_running = false;
++}
++
++/**
++ * @brief Set up periodic topology check for Blue-Green deployment.
++ *
++ * This function initializes and schedules a periodic event to check the topology
++ * status during Blue-Green deployment. It only activates when fast switchover
++ * is enabled.
++ *
++ * The function performs the following steps:
++ * 1. Checks if fast switchover is enabled; if not, it returns immediately.
++ * 2. Sets the monitoring interval based on the configured value.
++ * 3. Creates a persistent event for periodic topology checks.
++ * 4. Schedules the event to run at the specified interval.
++ *
++ * @note The actual topology check is performed by the do_topology_check function,
++ *       which is set as the callback for the event.
++ *
++ * @see fast_switchover
++ * @see cf_topology_monitoring_interval
++ * @see do_topology_check
++ */
++
++static void topology_check_setup(void)
++{
++	// Initialize interval from runtime-configured value
++	blue_green_topology_monitoring_interval.tv_sec = cf_topology_monitoring_interval/USEC;
++	blue_green_topology_monitoring_interval.tv_usec = 0;
++
++	event_del(&blue_green_topology_check_ev);
++    /* Set up periodic event */
++    event_assign(&blue_green_topology_check_ev, pgb_event_base, -1, EV_PERSIST, do_topology_check, NULL);
++    if (event_add(&blue_green_topology_check_ev, &blue_green_topology_monitoring_interval) < 0)
++		log_warning("event_add failed for blue green topology check, errno : %s", strerror(errno));
++}
++
 +/*
 + * Used to pre-create connection pools at pgbouncer init time.
 + */
@@ -312,6 +434,10 @@ index 5131ea5..c39e84c 100644
 +		PgPool *pool = get_pool(fast_switchover_db, fast_switchover_db->forced_user_credentials);
 +		if (!pool)
 +			fatal("pool could not be created for %s", fast_switchover_db->name);
++		pool->num_nodes = 0;
++
++		if (fast_switchover_db->recovery_query)
++			topology_check_setup();
 +	} else {
 +		fatal("Failed to create a connection pool for database: %s. Username is missing. To enable fast switchover, "
 +			   "please provide a user for this database in config.", fast_switchover_db->name);
@@ -331,7 +457,7 @@ index 5131ea5..c39e84c 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -494,6 +723,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -494,6 +846,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
@@ -339,7 +465,7 @@ index 5131ea5..c39e84c 100644
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
  		} else if (age >= server_lifetime) {
-@@ -877,6 +1107,8 @@ void kill_database(PgDatabase *db)
+@@ -877,6 +1230,8 @@ void kill_database(PgDatabase *db)
  	if (db->forced_user_credentials)
  		slab_free(credentials_cache, db->forced_user_credentials);
  	free(db->connect_query);

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 5131ea5..88e6fe8 100644
+index 5131ea5..c39e84c 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
 @@ -24,6 +24,8 @@
@@ -11,7 +11,7 @@ index 5131ea5..88e6fe8 100644
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
  static struct event full_maint_ev;
-@@ -127,21 +129,158 @@ void resume_all(void)
+@@ -127,21 +129,159 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -75,7 +75,8 @@ index 5131ea5..88e6fe8 100644
 +
 +	log_debug("launch_recheck: for db: %s, global_writer? %s", pool->db->name, global_writer ? global_writer->db->name : "no global_writer");
 +
-+	if (!pool->db->topology_query) {
++	/* Do not use cached values for any pool database when the fast switchover feature is disabled. */
++	if (is_fast_switchover_disabled_for_pool(pool)) {
 +		log_debug("launch_recheck: no topology_query for this pool, so proceeding without cache");
 +	} else if (global_writer) {
 +		log_debug("launch_recheck: global writer is set: using cached pool: %s", global_writer->db->name);
@@ -176,14 +177,19 @@ index 5131ea5..88e6fe8 100644
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -156,6 +295,31 @@ static void launch_recheck(PgPool *pool)
+@@ -156,6 +296,36 @@ static void launch_recheck(PgPool *pool)
  			need_check = false;
  	}
  
 +	if (fast_switchover && pool->db->topology_query) {
 +		if (!global_writer) {
 +			client->pool->checking_for_new_writer = true;
-+			recovery_query = strdup("select pg_is_in_recovery()");
++			/* If the customer has configured a recovery query, use the customer-defined recovery query. */
++			if (pool->db->recovery_query) {
++				recovery_query = strdup(pool->db->recovery_query);
++			} else {
++				recovery_query = strdup("select pg_is_in_recovery()");
++			}
 +			if (recovery_query == NULL) {
 +				log_error("strdup: no mem for pg_is_in_recovery()");
 +				return;
@@ -208,7 +214,7 @@ index 5131ea5..88e6fe8 100644
  	if (need_check) {
  		/* send test query, wait for result */
  		slog_debug(server, "P: checking: %s", q);
-@@ -210,11 +374,22 @@ static void per_loop_activate(PgPool *pool)
+@@ -210,11 +380,22 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -233,7 +239,7 @@ index 5131ea5..88e6fe8 100644
  			break;
  		}
  	}
-@@ -306,10 +481,7 @@ static int per_loop_wait_close(PgPool *pool)
+@@ -306,10 +487,7 @@ static int per_loop_wait_close(PgPool *pool)
  	return count;
  }
  
@@ -245,7 +251,7 @@ index 5131ea5..88e6fe8 100644
  {
  	struct List *item;
  	PgPool *pool;
-@@ -318,6 +490,7 @@ void per_loop_maint(void)
+@@ -318,6 +496,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -253,7 +259,7 @@ index 5131ea5..88e6fe8 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -329,13 +502,32 @@ void per_loop_maint(void)
+@@ -329,13 +508,32 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -287,7 +293,7 @@ index 5131ea5..88e6fe8 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -374,6 +566,37 @@ void per_loop_maint(void)
+@@ -374,6 +572,37 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -325,19 +331,20 @@ index 5131ea5..88e6fe8 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -494,6 +717,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -494,6 +723,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
-+			   && (pool->db && !pool->db->topology_query)
++			   && (pool->db && is_fast_switchover_disabled_for_pool(pool))
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
-		} else if (age >= server_lifetime) {
-@@ -877,6 +1101,7 @@ void kill_database(PgDatabase *db)
-	if (db->forced_user_credentials)
-		slab_free(credentials_cache, db->forced_user_credentials);
+ 		} else if (age >= server_lifetime) {
+@@ -877,6 +1107,8 @@ void kill_database(PgDatabase *db)
+ 	if (db->forced_user_credentials)
+ 		slab_free(credentials_cache, db->forced_user_credentials);
  	free(db->connect_query);
 +	free(db->topology_query);
++	free(db->recovery_query);
  	if (db->inactive_time) {
  		statlist_remove(&autodatabase_idle_list, &db->head);
  	} else {

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,12 +1,13 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 5131ea5..0c93e5a 100644
+index 5131ea5..edd6b7f 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
-@@ -24,9 +24,15 @@
+@@ -24,9 +24,16 @@
  
  #include <usual/slab.h>
  
 +bool fast_switchover = false;
++bool is_topology_monitoring_job_enabled = false;
 +
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
@@ -18,7 +19,7 @@ index 5131ea5..0c93e5a 100644
  extern bool any_user_level_server_timeout_set;
  extern bool any_user_level_client_timeout_set;
  
-@@ -127,21 +133,159 @@ void resume_all(void)
+@@ -127,21 +134,159 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -184,7 +185,7 @@ index 5131ea5..0c93e5a 100644
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -156,6 +300,36 @@ static void launch_recheck(PgPool *pool)
+@@ -156,6 +301,36 @@ static void launch_recheck(PgPool *pool)
  			need_check = false;
  	}
  
@@ -221,7 +222,7 @@ index 5131ea5..0c93e5a 100644
  	if (need_check) {
  		/* send test query, wait for result */
  		slog_debug(server, "P: checking: %s", q);
-@@ -210,11 +384,22 @@ static void per_loop_activate(PgPool *pool)
+@@ -210,11 +385,26 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -238,6 +239,10 @@ index 5131ea5..0c93e5a 100644
 +				log_debug("launch_new_connection loop: going to try to use pool cache since this pool was a writer: last_connect_failed (%d)",
 +						pool->last_connect_failed);
 +				launch_recheck(pool, client);
++				if (client->pool->last_connect_failed) {
++					log_debug("launch_new_connection loop: no used and idle server, launch new connection to pool: %s", client->pool->db->name);
++					launch_new_connection(client->pool, /* evict_if_needed = */ true);
++				}
 +			} else {
 +				log_debug("launch_new_connection loop: need to launch new connection because pool is not already a writer");
 +				launch_new_connection(pool, /* evict_if_needed= */ true);
@@ -246,19 +251,84 @@ index 5131ea5..0c93e5a 100644
  			break;
  		}
  	}
-@@ -306,10 +491,7 @@ static int per_loop_wait_close(PgPool *pool)
- 	return count;
+@@ -307,9 +497,74 @@ static int per_loop_wait_close(PgPool *pool)
  }
  
--/*
+ /*
 - * this function is called for each event loop.
-- */
++ * Checks whether all default pools involved in fast switchover are healthy.
++ *
++ * A pool is considered healthy if:
++ *   - It previously experienced a connection failure (`last_connect_failed`)
++ *   - It has a defined `recovery_query` to verify recovery status
++ *
++ * This function is typically used during blue-green deployment scenarios or fast
++ * switchover to ensure all related pools are fully recovered before proceeding
++ * with switchover-related state transitions.
++ *
++ * Returns:
++ *   true  - All relevant pools are healthy
++ *   false - One or more pools are still unhealthy
+  */
 -void per_loop_maint(void)
++static bool are_all_fast_switchover_pools_healthy(void) {
++	bool any_connect_failed = false;
++	struct List *item;
++	PgPool *next_pool;
++
++	statlist_for_each(item, &pool_list) {
++		next_pool = container_of(item, PgPool, head);
++		if (next_pool->db->blue_green_deployment_db_type != DEFAULT || !next_pool->db->recovery_query) {
++			continue;
++		}
++		if (!next_pool->last_connect_failed) {
++			continue;
++		}
++		log_debug("handle_server_work: Some pool connections are still not healthy. db name : %s", next_pool->db->name);
++		any_connect_failed = true;
++	}
++	return !any_connect_failed;
++}
++
++/*
++ * Checks blue-green deployment pool states and updates flags accordingly.
++ *
++ * This function:
++ *  - Disables fast switchover mode if the switchover is complete and all connection pools are healthy.
++ *  - Resets the "source instance was down before switchover" flag once the source is available and pools are healthy.
++ *
++ * The health check (are_all_fast_switchover_pools_healthy) is only run when either
++ * 'routing_traffic_to_target_complete' or
++ * 'source_instance_down_before_switchover' is true.
++ */
++static void reset_blue_green_switchover_flags() {
++	if (routing_traffic_to_target_complete) {
++		/*
++		 * After a successful switchover, once all fast switchover connection pools are confirmed to be healthy,
++		 * disable the fast switchover feature to restore normal operation.
++		 */
++		if (are_all_fast_switchover_pools_healthy()) {
++			fast_switchover = false;
++			routing_traffic_to_target_complete = false;
++			log_warning("All default pools are up and connected after switchover. Disabling the fast switchover for blue green.");
++		}
++	} else if (source_instance_down_before_switchover) {
++		/*
++		 * Scenario: Source was down before switchover, is now available.
++		 * Wait until all pools are healthy, then reset the flag.
++		 */
++		if (are_all_fast_switchover_pools_healthy()) {
++			log_warning("All pools are up and connected. Resetting source_instance_down_before_switchover flag.");
++			source_instance_down_before_switchover = false;
++		}
++	}
++}
++
 +static void loop_maint(bool initialize)
  {
  	struct List *item;
  	PgPool *pool;
-@@ -318,6 +500,7 @@ void per_loop_maint(void)
+@@ -318,6 +573,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -266,7 +336,15 @@ index 5131ea5..0c93e5a 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -329,13 +512,40 @@ void per_loop_maint(void)
+@@ -325,17 +581,48 @@ void per_loop_maint(void)
+ 			force_suspend = true;
+ 	}
+ 
++	if (fast_switchover && (routing_traffic_to_target_complete || source_instance_down_before_switchover)) {
++		reset_blue_green_switchover_flags();
++	}
++
+ 	statlist_for_each(item, &pool_list) {
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -308,7 +386,7 @@ index 5131ea5..0c93e5a 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -374,6 +584,148 @@ void per_loop_maint(void)
+@@ -374,6 +661,174 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -338,7 +416,7 @@ index 5131ea5..0c93e5a 100644
 +	bool res = true;
 +	static bool is_running = false;
 +
-+	if (!fast_switchover) {
++	if (!is_topology_monitoring_job_enabled) {
 +		event_del(&blue_green_topology_check_ev);
 +		return;
 +	}
@@ -413,10 +491,20 @@ index 5131ea5..0c93e5a 100644
 +	blue_green_topology_monitoring_interval.tv_usec = 0;
 +
 +	event_del(&blue_green_topology_check_ev);
++	is_topology_monitoring_job_enabled = true;
 +    /* Set up periodic event */
 +    event_assign(&blue_green_topology_check_ev, pgb_event_base, -1, EV_PERSIST, do_topology_check, NULL);
 +    if (event_add(&blue_green_topology_check_ev, &blue_green_topology_monitoring_interval) < 0)
 +		log_warning("event_add failed for blue green topology check, errno : %s", strerror(errno));
++}
++
++static void cleanup_fast_switchover_db(PgDatabase ***fast_switchover_db) {
++	if (*fast_switchover_db) {
++		free(*fast_switchover_db);
++		*fast_switchover_db = NULL;
++		fast_switchover_configured_db_count = 0;
++		fast_switchover_db_capacity = 0;
++	}
 +}
 +
 +/*
@@ -424,25 +512,41 @@ index 5131ea5..0c93e5a 100644
 + */
 +void run_once_to_init(void)
 +{
++	bool bgd_fast_switchover = false;
 +	if (!fast_switchover) {
++		cleanup_fast_switchover_db(&fast_switchover_db);
 +		log_debug("database does not have fast_switchovers enabled, so will not precreate pools to nodes");
 +		return;
 +	}
 +
-+	log_debug("creating pool for %s", fast_switchover_db->name);
-+	if (fast_switchover_db && fast_switchover_db->forced_user_credentials) {
-+		PgPool *pool = get_pool(fast_switchover_db, fast_switchover_db->forced_user_credentials);
-+		if (!pool)
-+			fatal("pool could not be created for %s", fast_switchover_db->name);
-+		pool->num_nodes = 0;
++	/*
++	 * Loop through all databases configured for fast switchover and attempt to create
++	 * a connection pool for each.
++	 */
++	for (int db_index = 0; db_index<fast_switchover_configured_db_count; db_index++) {
++		log_debug("creating pool for %s", fast_switchover_db[db_index]->name);
++		if (fast_switchover_db[db_index]->forced_user_credentials) {
++			PgPool *pool = get_pool(fast_switchover_db[db_index], fast_switchover_db[db_index]->forced_user_credentials);
++			if (!pool) {
++				cleanup_fast_switchover_db(&fast_switchover_db);
++				fatal("pool could not be created for %s", fast_switchover_db[db_index]->name);
++			}
++			pool->num_nodes = 0;
 +
-+		if (fast_switchover_db->recovery_query)
-+			topology_check_setup();
-+	} else {
-+		fatal("Failed to create a connection pool for database: %s. Username is missing. To enable fast switchover, "
-+			   "please provide a user for this database in config.", fast_switchover_db->name);
++			if (fast_switchover_db[db_index]->recovery_query)
++				bgd_fast_switchover = true;
++		} else {
++			cleanup_fast_switchover_db(&fast_switchover_db);
++			fatal("Failed to create a connection pool for database: %s. Username is missing. To enable fast switchover, "
++			    "please provide a user for this database in config.", fast_switchover_db[db_index]->name);
++		}
++
 +	}
 +
++	cleanup_fast_switchover_db(&fast_switchover_db);
++	if(bgd_fast_switchover) {
++		topology_check_setup();
++	}
 +	loop_maint(true);
 +}
 +
@@ -457,7 +561,7 @@ index 5131ea5..0c93e5a 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -494,6 +846,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -494,6 +949,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
@@ -465,7 +569,7 @@ index 5131ea5..0c93e5a 100644
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
  		} else if (age >= server_lifetime) {
-@@ -877,6 +1230,8 @@ void kill_database(PgDatabase *db)
+@@ -877,6 +1333,8 @@ void kill_database(PgDatabase *db)
  	if (db->forced_user_credentials)
  		slab_free(credentials_cache, db->forced_user_credentials);
  	free(db->connect_query);

--- a/src/loader.c.diff
+++ b/src/loader.c.diff
@@ -1,13 +1,13 @@
 diff --git a/src/loader.c b/src/loader.c
-index fd2e7ab..9692913 100644
+index 4018d78..5e1718f 100644
 --- a/src/loader.c
 +++ b/src/loader.c
 @@ -32,6 +32,7 @@
-
+ 
  bool any_user_level_timeout_set;
  bool any_user_level_client_timeout_set;
 +PgDatabase *fast_switchover_db;
-
+ 
  /* parse parameter name before '=' */
  static char *cstr_get_key(char *p, char **dst_p)
 @@ -57,12 +58,20 @@ static char *cstr_unquote_value(char *p)
@@ -31,8 +31,8 @@ index fd2e7ab..9692913 100644
  		*s++ = *p++;
  	}
  	/* terminate actual value */
-@@ -243,6 +252,76 @@ fail:
-	free(host);
+@@ -243,6 +252,81 @@ fail:
+ 	free(host);
  	return false;
  }
 +
@@ -81,6 +81,11 @@ index fd2e7ab..9692913 100644
 +		if (!new_db->topology_query)
 +			goto oom;
 +	}
++	if (new_db->recovery_query) {
++		new_db->recovery_query = strdup(db->recovery_query);
++		if (!new_db->recovery_query)
++			goto oom;
++	}
 +	if (db->auth_dbname) {
 +		new_db->auth_dbname = strdup(db->auth_dbname);
 +		if (!new_db->auth_dbname)
@@ -108,15 +113,16 @@ index fd2e7ab..9692913 100644
  /* fill PgDatabase from connstr */
  bool parse_database(void *base, const char *name, const char *connstr)
  {
-@@ -273,6 +352,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -273,6 +357,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	char *datestyle = NULL;
  	char *timezone = NULL;
  	char *connect_query = NULL;
 +	char *topology_query = NULL;
++	char *recovery_query = NULL;
  	char *appname = NULL;
-	char *auth_query = NULL;
+ 	char *auth_query = NULL;
  
-@@ -358,8 +438,20 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -358,8 +444,35 @@ bool parse_database(void *base, const char *name, const char *connstr)
  				goto fail;
  			}
  		} else if (strcmp("connect_query", key) == 0) {
@@ -124,7 +130,11 @@ index fd2e7ab..9692913 100644
 +				log_error("connect_query cannot be used if topology_query is set");
 +				goto fail;
 +			}
-			if (!set_param_value(&connect_query, val))
++			if (recovery_query != NULL) {
++				log_error("connect_query cannot be used if recovery_query is set");
++				goto fail;
++			}
+ 			if (!set_param_value(&connect_query, val))
  				goto fail;
 +		} else if (strcmp("topology_query", key) == 0) {
 +			if (connect_query != NULL) {
@@ -134,31 +144,53 @@ index fd2e7ab..9692913 100644
 +			if (!set_param_value(&topology_query, val))
 +				goto fail;
 +			fast_switchover = true;
++		} else if (strcmp("recovery_query", key) == 0) {
++			if (connect_query != NULL) {
++				log_error("recovery_query cannot be used if connect_query is set");
++				goto fail;
++			}
++			if (topology_query == NULL) {
++				log_error("recovery_query cannot be used if topology_query is not set");
++				goto fail;
++			}
++			if (!set_param_value(&recovery_query, val))
++				goto fail;
  		} else if (strcmp("application_name", key) == 0) {
  			appname = val;
-		} else if (strcmp("auth_query", key) == 0) {
-@@ -399,6 +491,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 		} else if (strcmp("auth_query", key) == 0) {
+@@ -399,12 +512,16 @@ bool parse_database(void *base, const char *name, const char *connstr)
  			changed = true;
-		} else if (!strcmpeq(connect_query, db->connect_query)) {
+ 		} else if (!strcmpeq(connect_query, db->connect_query)) {
  			changed = true;
 +		} else if (!strcmpeq(topology_query, db->topology_query)) {
 +			changed = true;
-		} else if (!strcmpeq(db->auth_dbname, auth_dbname)) {
+ 		} else if (!strcmpeq(db->auth_dbname, auth_dbname)) {
  			changed = true;
-		} else if (!strcmpeq(db->auth_query, auth_query)) {
-@@ -423,8 +517,11 @@ bool parse_database(void *base, const char *name, const char *connstr)
-	db->server_lifetime = server_lifetime;
-	db->load_balance_hosts = load_balance_hosts;
+ 		} else if (!strcmpeq(db->auth_query, auth_query)) {
+ 			changed = true;
+ 		} else if (load_balance_hosts != db->load_balance_hosts) {
+ 			changed = true;
++		} else if (!strcmpeq(recovery_query, db->recovery_query)) {
++			changed = true;
+ 		}
+ 		if (changed)
+ 			tag_database_dirty(db);
+@@ -423,8 +540,14 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 	db->server_lifetime = server_lifetime;
+ 	db->load_balance_hosts = load_balance_hosts;
  	free(db->connect_query);
 +	free(db->topology_query);
++	free(db->recovery_query);
  	db->connect_query = connect_query;
 +	db->topology_query = topology_query;
-	connect_query = NULL;
++	db->recovery_query = recovery_query;
+ 	connect_query = NULL;
 +	topology_query = NULL;
-
-	if (!set_param_value(&db->auth_dbname, auth_dbname))
++	recovery_query = NULL;
+ 
+ 	if (!set_param_value(&db->auth_dbname, auth_dbname))
  		goto fail;
-@@ -486,6 +583,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -486,6 +609,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	/* remember dbname */
  	db->dbname = (char *)msg->buf + dbname_ofs;
  

--- a/src/loader.c.diff
+++ b/src/loader.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/loader.c b/src/loader.c
-index 4018d78..5e1718f 100644
+index 4018d78..5758e2d 100644
 --- a/src/loader.c
 +++ b/src/loader.c
 @@ -32,6 +32,7 @@
@@ -36,7 +36,7 @@ index 4018d78..5e1718f 100644
  	return false;
  }
 +
-+PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname)
++PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname, int port)
 +{
 +	PgPool *pool;
 +	PgDatabase *new_db = find_database(dbname);
@@ -65,7 +65,7 @@ index 4018d78..5e1718f 100644
 +	if (!new_db->host)
 +		goto oom;
 +
-+	new_db->port = db->port;
++	new_db->port = port;
 +	new_db->pool_size = db->pool_size;
 +	new_db->min_pool_size = db->min_pool_size;
 +	new_db->res_pool_size = db->res_pool_size;

--- a/src/loader.c.diff
+++ b/src/loader.c.diff
@@ -1,16 +1,21 @@
 diff --git a/src/loader.c b/src/loader.c
-index 4018d78..5758e2d 100644
+index 4018d78..fd00572 100644
 --- a/src/loader.c
 +++ b/src/loader.c
-@@ -32,6 +32,7 @@
+@@ -32,6 +32,12 @@
  
  bool any_user_level_timeout_set;
  bool any_user_level_client_timeout_set;
-+PgDatabase *fast_switchover_db;
++/*
++ * Dynamic array for databases that can participate in a fast switchover operation.
++ */
++PgDatabase **fast_switchover_db = NULL;
++int fast_switchover_configured_db_count = 0;
++int fast_switchover_db_capacity = 0;
  
  /* parse parameter name before '=' */
  static char *cstr_get_key(char *p, char **dst_p)
-@@ -57,12 +58,20 @@ static char *cstr_unquote_value(char *p)
+@@ -57,12 +63,20 @@ static char *cstr_unquote_value(char *p)
  	while (1) {
  		if (!*p)
  			return NULL;
@@ -31,7 +36,7 @@ index 4018d78..5758e2d 100644
  		*s++ = *p++;
  	}
  	/* terminate actual value */
-@@ -243,6 +252,81 @@ fail:
+@@ -243,6 +257,117 @@ fail:
  	free(host);
  	return false;
  }
@@ -110,10 +115,46 @@ index 4018d78..5758e2d 100644
 +	die("out of memory");
 +}
 +
++/*
++ * Adds a PgDatabase pointer to the dynamically growing fast_switchover_db array.
++ *
++ * This function ensures that the array has sufficient capacity by reallocating
++ * memory when needed. It starts with an initial capacity of 8 and doubles the
++ * size each time the current capacity is reached.
++ *
++ * Parameters:
++ *   db - Pointer to the PgDatabase to add to the fast switchover list.
++ *
++ * On allocation failure, the function calls fatal(), terminating the program.
++ */
++
++static void add_fast_switchover_db(PgDatabase *db)
++{
++	if (fast_switchover_configured_db_count >= fast_switchover_db_capacity) {
++		// Initial capacity of 8, double the size when needed
++		int new_capacity = fast_switchover_db_capacity == 0 ? 8 : fast_switchover_db_capacity * 2;
++		// Check for overflow
++		if (new_capacity < fast_switchover_db_capacity) {
++			fatal("fast_switchover_db capacity overflow");
++			return;
++		}
++
++		PgDatabase **new_array = realloc(fast_switchover_db, new_capacity * sizeof(PgDatabase *));
++		if (!new_array) {
++			fast_switchover_db_capacity = 0;
++			fast_switchover_configured_db_count = 0;
++			fatal("out of memory allocating fast_switchover_db array");
++		}
++		fast_switchover_db = new_array;
++		fast_switchover_db_capacity = new_capacity;
++	}
++	fast_switchover_db[fast_switchover_configured_db_count++] = db;
++}
++
  /* fill PgDatabase from connstr */
  bool parse_database(void *base, const char *name, const char *connstr)
  {
-@@ -273,6 +357,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -273,6 +398,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	char *datestyle = NULL;
  	char *timezone = NULL;
  	char *connect_query = NULL;
@@ -122,7 +163,7 @@ index 4018d78..5758e2d 100644
  	char *appname = NULL;
  	char *auth_query = NULL;
  
-@@ -358,8 +444,35 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -358,8 +485,35 @@ bool parse_database(void *base, const char *name, const char *connstr)
  				goto fail;
  			}
  		} else if (strcmp("connect_query", key) == 0) {
@@ -158,7 +199,7 @@ index 4018d78..5758e2d 100644
  		} else if (strcmp("application_name", key) == 0) {
  			appname = val;
  		} else if (strcmp("auth_query", key) == 0) {
-@@ -399,12 +512,16 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -399,12 +553,16 @@ bool parse_database(void *base, const char *name, const char *connstr)
  			changed = true;
  		} else if (!strcmpeq(connect_query, db->connect_query)) {
  			changed = true;
@@ -175,7 +216,7 @@ index 4018d78..5758e2d 100644
  		}
  		if (changed)
  			tag_database_dirty(db);
-@@ -423,8 +540,14 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -423,8 +581,14 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	db->server_lifetime = server_lifetime;
  	db->load_balance_hosts = load_balance_hosts;
  	free(db->connect_query);
@@ -190,12 +231,13 @@ index 4018d78..5758e2d 100644
  
  	if (!set_param_value(&db->auth_dbname, auth_dbname))
  		goto fail;
-@@ -486,6 +609,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -486,6 +650,10 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	/* remember dbname */
  	db->dbname = (char *)msg->buf + dbname_ofs;
  
-+	if (fast_switchover)
-+		fast_switchover_db = db;
++	if (fast_switchover && db->topology_query) {
++		add_fast_switchover_db(db);
++	}
 +
  	free(tmp_connstr);
  	return true;

--- a/src/main.c.diff
+++ b/src/main.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/main.c b/src/main.c
-index 88b94c8..6988314 100644
+index 88b94c8..2bba9c2 100644
 --- a/src/main.c
 +++ b/src/main.c
 @@ -122,7 +122,9 @@ char *cf_track_extra_parameters;
@@ -12,15 +12,16 @@ index 88b94c8..6988314 100644
  int cf_res_pool_size;
  usec_t cf_res_pool_timeout;
  int cf_max_db_connections;
-@@ -135,6 +137,7 @@ int cf_server_reset_query_always;
+@@ -135,6 +137,8 @@ int cf_server_reset_query_always;
  char *cf_server_check_query;
  usec_t cf_server_check_delay;
  int cf_server_fast_close;
 +usec_t cf_server_failed_delay;
++usec_t cf_topology_monitoring_interval;
  int cf_server_round_robin;
  int cf_disable_pqexec;
  usec_t cf_dns_max_ttl;
-@@ -176,6 +179,11 @@ int cf_log_disconnections;
+@@ -176,6 +180,11 @@ int cf_log_disconnections;
  int cf_log_pooler_errors;
  int cf_application_name_add_host;
  
@@ -32,35 +33,37 @@ index 88b94c8..6988314 100644
  int cf_client_tls_sslmode;
  char *cf_client_tls_protocols;
  char *cf_client_tls_ca_file;
-@@ -290,18 +298,27 @@ static const struct CfKey bouncer_params [] = {
-	CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
-	CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
-	CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
+@@ -290,18 +299,29 @@ static const struct CfKey bouncer_params [] = {
+ 	CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
+ 	CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
+ 	CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
 +	// in seconds. maps to 100ms by default.
 +	CF_ABS("polling_frequency", CF_TIME_USEC, cf_polling_frequency, 0, ".1"),
-	CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
-	CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
-	CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
-	CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
+ 	CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
+ 	CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
+ 	CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
+ 	CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
 +	CF_ABS("recreate_disconnected_pools", DEFER_OPS, cf_recreate_disconnected_pools, 0, "1"),
-	CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
-	CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
-	CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
+ 	CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
+ 	CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
+ 	CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
 +	/* pgbouncer-rr extensions */
 +	CF_ABS("routing_rules_py_module_file", CF_STR, cf_routing_rules_py_module_file, 0, "not_enabled"),
 +	CF_ABS("rewrite_query_py_module_file", CF_STR, cf_rewrite_query_py_module_file, 0, "not_enabled"),
 +	CF_ABS("rewrite_query_disconnect_on_failure", CF_STR, cf_rewrite_query_disconnect_on_failure, 0, "false"),
-	CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
-	CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
-	CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
-	CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
-	CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
+ 	CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
+ 	CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
+ 	CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
+ 	CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
+ 	CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
 +	// allow backing off after switchover/failover. The delay to wait until reopening failed connections.
 +	CF_ABS("server_failed_delay", CF_TIME_USEC, cf_server_failed_delay, 0, "30"),
-	CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
-	CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
-	CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
-@@ -1129,6 +1146,8 @@ int main(int argc, char *argv[])
++	/* Set the topology monitoring interval (in seconds) between BGD metadata status checks during fast switchover */
++	CF_ABS("topology_monitoring_interval", CF_TIME_USEC, cf_topology_monitoring_interval, 0, "60"),
+ 	CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
+ 	CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
+ 	CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
+@@ -1129,6 +1149,8 @@ int main(int argc, char *argv[])
  	}
  
  	write_pidfile();

--- a/src/objects.c.diff
+++ b/src/objects.c.diff
@@ -1,17 +1,17 @@
 diff --git a/src/objects.c b/src/objects.c
-index 5603c74..54f18ec 100644
+index d64a523..2448173 100644
 --- a/src/objects.c
 +++ b/src/objects.c
-@@ -769,14 +769,20 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials)
+@@ -766,14 +766,20 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials)
  {
  	struct List *item;
  	PgPool *pool;
 +	PgPool *global_writer = NULL;
-
-	if (!db || !user_credentials)
+ 
+ 	if (!db || !user_credentials)
  		return NULL;
-
-	list_for_each(item, &user_credentials->global_user->pool_list) {
+ 
+ 	list_for_each(item, &user_credentials->global_user->pool_list) {
  		pool = container_of(item, PgPool, map_head);
 -		if (pool->db == db)
 +		if (pool->db == db) {
@@ -22,20 +22,23 @@ index 5603c74..54f18ec 100644
  			return pool;
 +		}
  	}
-
-	return new_pool(db, user_credentials);
-@@ -1175,6 +1181,10 @@ bool life_over(PgSocket *server)
- 	usec_t last_kill = now - pool->last_lifetime_disconnect;
-	usec_t server_lifetime = pool_server_lifetime(pool);
  
-+	// never close the pools when using fast switchovers
-+	if (pool->db && pool->db->topology_query)
+ 	return new_pool(db, user_credentials);
+@@ -1172,6 +1178,13 @@ bool life_over(PgSocket *server)
+ 	usec_t last_kill = now - pool->last_lifetime_disconnect;
+ 	usec_t server_lifetime = pool_server_lifetime(pool);
+ 
++	/*
++	 * never close the pools when using fast switchovers.
++	 * Including a check for fast switchover feature enablement as well. For Blue-Green Deployment, the fast switchover feature will be disabled after the switchover is complete.
++	 */
++	if (pool->db && pool->db->topology_query && fast_switchover)
 +		return false;
 +
-	if (age < server_lifetime)
+ 	if (age < server_lifetime)
  		return false;
  
-@@ -2022,6 +2032,8 @@ PgSocket *accept_client(int sock, bool is_unix)
+@@ -2015,6 +2028,8 @@ PgSocket *accept_client(int sock, bool is_unix)
  /* client managed to authenticate, send welcome msg and accept queries */
  bool finish_client_login(PgSocket *client)
  {
@@ -43,8 +46,8 @@ index 5603c74..54f18ec 100644
 +
  	if (client->db->fake) {
  		if (cf_log_connections)
-			slog_info(client, "login failed: db=%s user=%s", client->db->name, client->login_user_credentials->name);
-@@ -2041,6 +2053,21 @@ bool finish_client_login(PgSocket *client)
+ 			slog_info(client, "login failed: db=%s user=%s", client->db->name, client->login_user_credentials->name);
+@@ -2029,6 +2044,21 @@ bool finish_client_login(PgSocket *client)
  
  	switch (client->state) {
  	case CL_LOGIN:

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..eb8ded7 100644
+index c6e5efe..1d7a766 100644
 --- a/src/server.c
 +++ b/src/server.c
 @@ -27,6 +27,125 @@
@@ -128,7 +128,19 @@ index c6e5efe..eb8ded7 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -122,6 +241,9 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -115,6 +234,11 @@ const char * kill_pool_logins_server_error(PgPool *pool, PktHdr *errpkt)
+ 	return msg;
+ }
+ 
++static bool should_reset_global_writer(PgSocket *server) {
++	return fast_switchover && server->pool->db->recovery_query &&
++	(source_instance_down_before_switchover || routing_traffic_to_target_complete);
++}
++
+ /* process packets on server auth phase */
+ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ {
+@@ -122,6 +246,9 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
@@ -138,7 +150,7 @@ index c6e5efe..eb8ded7 100644
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +255,30 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +260,31 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
  		case PqMsg_ReadyForQuery:
  		case PqMsg_ParameterStatus:
@@ -162,6 +174,7 @@ index c6e5efe..eb8ded7 100644
 +				log_warning("Fast switchover disabled: topology query failed. The current cluster node may not be part of a Blue-Green deployment. "
 +					"Feature will be re-enabled after a successful topology query following RELOAD.");
 +				fast_switchover = false;
++				is_topology_monitoring_job_enabled = false;
 +			} else if (fast_switchover) {
 +				fatal("does the topology table exist?");
 +			}
@@ -169,7 +182,7 @@ index c6e5efe..eb8ded7 100644
  		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +292,53 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +298,53 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -203,7 +216,7 @@ index c6e5efe..eb8ded7 100644
 +				}
 +
 +				/* Set up a new connection pool based on topology data. */
-+				if (setup_new_pool(server, topology, false/* for freshly pool connections*/) == NULL) {
++				if (setup_new_pool(server->pool, topology) == NULL) {
 +					// Handle setup failure if needed
 +					log_debug("Failed to initialize new connection pool for host '%s'. Possible issue with memory allocation, hostname parsing, or connection launch.",
 +						topology->endpoint);
@@ -223,7 +236,15 @@ index c6e5efe..eb8ded7 100644
  	case PqMsg_ErrorResponse:
  		/*
  		 * If we cannot log into the server, then we drop all clients
-@@ -201,7 +388,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -189,7 +382,6 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 	case PqMsg_ParameterStatus:
+ 		res = load_parameter(server, pkt, true);
+ 		break;
+-
+ 	case PqMsg_ReadyForQuery:
+ 		if (server->exec_on_connect) {
+ 			server->exec_on_connect = false;
+@@ -201,8 +393,45 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -234,7 +255,7 @@ index c6e5efe..eb8ded7 100644
 +			if (!res)
 +				disconnect_server(server, false, "exec_on_connect query failed");
 +			break;
-+		} else if (fast_switchover && source_instance_down_before_switchover && server->pool->db->recovery_query) {
++		} else if (should_reset_global_writer(server)) {
 +			if (server->pool->db->blue_green_deployment_db_type == DEFAULT) {
 +				/*
 +				 * This scenario occurs when the source instance was down before the switchover and has now become available.
@@ -243,31 +264,14 @@ index c6e5efe..eb8ded7 100644
 +				 * In this case, we wait for the source instance to come back online. Once it is available,
 +				 * we reset the global writer to the source instance.
 +				 */
-+				log_debug("Setting the global writer once the source instance comes up : db_name %s", server->pool->db->name);
++				log_debug("Setting the global writer once the default pool comes up after shut down: db_name %s", server->pool->db->name);
 +				if (!server->pool->parent_pool) {
 +					server->pool->parent_pool = server->pool;
 +				}
 +				server->pool->parent_pool->global_writer = server->pool;
 +			}
-+			source_instance_down_before_switchover = false;
-+		} else if (fast_switchover && server->pool->db->recovery_query && routing_traffic_to_target_complete) {
-+			if (server->pool->db->blue_green_deployment_db_type == DEFAULT) {
-+				/*
-+				 * After the switchover is completed, we set 'routing_traffic_to_target_complete' to true in 'handle_server_work'.
-+				 * Once DNS resolution is complete for the target instance, the new DNS becomes available for queries.
-+				 * Here, we monitor the startup status of the new blue instance and the 'routing_traffic_to_target_complete' flag.
-+				 * Once both conditions are met, we disable the fast switchover feature.
-+				 */
-+				log_warning("Once the switchover is completed for DB : %s, disabling the fast switchover and reverting PgBouncer to standard connection pooling mode.", server->pool->db->name);
-+				if (!server->pool->parent_pool) {
-+					server->pool->parent_pool = server->pool;
-+				}
-+				server->pool->parent_pool->global_writer = server->pool;
-+				fast_switchover = false;
-+				routing_traffic_to_target_complete = false;
-+			}
-+		}
-+
+ 		}
+ 
 +		if (server->pool->db->topology_query && server->pool->initial_writer_endpoint && server->pool->num_nodes < 2) {
 +			if (server->pool->db->recovery_query) {
 +				/*
@@ -275,16 +279,54 @@ index c6e5efe..eb8ded7 100644
 +				 * In this case, PgBouncer will not crash. Instead, it will disable the fast switchover feature and revert to the standard PgBouncer behavior.
 +				 */
 +				fast_switchover = false;
++				is_topology_monitoring_job_enabled = false;
 +				log_warning("topology_query did not find at least 2 nodes to use Blue Green Deployment fast switchover for DB: '%s'. PgBouncer reverting to standard connection pooling mode.", server->pool->db->name);
 +			} else {
 +				fatal("topology_query did not find at least 2 nodes to use fast switchover in DB: '%s'. Is the topology table populated with entries?", server->pool->db->name);
 +			}
- 		}
++		}
 +		server->pool->initial_writer_endpoint = false;
- 
++
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -352,6 +592,123 @@ int user_client_max_connections(PgGlobalUser *user)
+ 		server->ready = true;
+@@ -287,6 +516,20 @@ int pool_pool_size(PgPool *pool)
+ /* min_pool_size of the pool's db */
+ int pool_min_pool_size(PgPool *pool)
+ {
++	PgPool *global_writer;
++	if (fast_switchover && pool->db->blue_green_deployment_db_type == BLUE_GREEN_TARGET) {
++		/*
++		 * In a blue-green deployment during a fast switchover to switch the connection to green:
++		 *   - We maintan the pool size as global writer active connections
++		 *   - If global writer found, return the total number of active server connections
++		 *     currently associated with that writer pool.
++		 */
++		global_writer = get_global_writer(pool);
++		if (global_writer) {
++			return global_writer->active_server_list.cur_count;
++		}
++	}
++
+ 	return database_min_pool_size(pool->db);
+ }
+ 
+@@ -302,6 +545,14 @@ usec_t pool_server_lifetime(PgPool *pool)
+ /* min_pool_size of the db */
+ int database_min_pool_size(PgDatabase *db)
+ {
++	if (fast_switchover && db->blue_green_deployment_db_type == BLUE_GREEN_SOURCE) {
++		/*
++		 *
++		 * In a blue-green deployment during a fast switchover:
++		 *   - For Source instance pool maintain only one connection to run the topolgy query
++		*/
++		return 1;
++	}
+ 	if (db->min_pool_size < 0)
+ 		return cf_min_pool_size;
+ 	else
+@@ -352,6 +603,225 @@ int user_client_max_connections(PgGlobalUser *user)
  		return user->max_user_client_connections;
  }
  
@@ -301,8 +343,7 @@ index c6e5efe..eb8ded7 100644
 +static bool should_update_global_writer(const char *data, enum BlueGreenDeploymentDBType db_type) {
 +	return	(strcmp(data, "f") == 0) ||
 +			(strcmp(data, SWITCHOVER_IN_POST_PROCESSING) == 0) ||
-+			(strcmp(data, SWITCHOVER_COMPLETED) == 0) ||
-+			((strcmp(data, AVAILABLE) == 0) && (db_type == DEFAULT));
++			(strcmp(data, SWITCHOVER_COMPLETED) == 0);
 +}
 +
 +static bool find_target_endpoint_to_setup_connection(PgSocket *server, TopologyData *topology) {
@@ -322,35 +363,82 @@ index c6e5efe..eb8ded7 100644
 +}
 +
 +/*
-+ * Checks if the Blue-Green target instance has a failed connection or configuration mismatch.
++ * Free all entries in the failed_pools list and the list itself.
++ * Safe to call with NULL.
++ */
++static void cleanup_failed_pool_entry(struct StatList *failed_pools) {
++	struct List *item, *tmp;
++	if (failed_pools) {
++		// Cleanup
++		statlist_for_each_safe(item, failed_pools, tmp) {
++			struct FailedPgPool *entry = container_of(item, struct FailedPgPool, head);
++			statlist_remove(failed_pools, item);
++			free(entry);
++		}
++		free(failed_pools);
++	}
++}
++
++/**
++ * check_target_pools_with_failed_connection - Identify target pools with failed connections or mismatched configuration.
 + *
-+ * This function scans through the pool list to find the target (green) pool.
-+ * It returns the target pool if any of the following conditions are true:
-+ * - The last connection attempt to the target failed
-+ * - The configured port number differs from the expected topology port
-+ * - The configured host does not match the expected topology endpoint
++ * This function iterates over the list of configured connection pools and checks for
++ * those that are designated as "target" in a blue-green deployment. It identifies
++ * target pools that meet any of the following failure criteria:
++ *   - The last connection attempt failed (`last_connect_failed` is true),
++ *   - The port number in the pool configuration differs from the current topology port,
++ *   - The host name in the pool configuration does not match the current topology endpoint.
 + *
-+ * Returns NULL if the target instance is healthy and properly configured.
++ * For each target pool that matches one or more of these failure conditions, a
++ * `FailedPgPool` entry is created and added to a `StatList` of failed pools. This
++ * allows the system to later act on unhealthy or outdated connections during
++ * deployment or failover operations.
++ *
++ * Memory for the returned `StatList` is dynamically allocated and must be freed by
++ * the caller. If memory allocation fails at any point, the function logs an error
++ * and returns NULL.
++ *
++ * @param topology Pointer to the current deployment topology containing expected host and port.
++ * @return A pointer to a `StatList` containing failed target pools, or NULL on failure.
 + */
 +
++static struct StatList* check_target_pools_with_failed_connection(TopologyData *topology) {
++    struct List *item;
++    PgPool *next_pool = NULL;
++    struct StatList *failed_pools = NULL;
 +
-+static PgPool* check_if_target_has_failed_connection(TopologyData *topology) {
-+	struct List *item;
-+	PgPool *next_pool = NULL;
++    // Initialize the list to store failed pools
++    failed_pools = malloc(sizeof(struct StatList));
++    if (!failed_pools) {
++		log_error("Failed to allocate memory for failed_pools list");
++		return NULL;
++    }
 +
-+	// Look through pool list for target instance's pool
-+	statlist_for_each(item, &pool_list) {
++    statlist_init(failed_pools, "failed_pools");
++
++    // Look through pool list for target instance's pool
++    statlist_for_each(item, &pool_list) {
 +		next_pool = container_of(item, PgPool, head);
 +		if (next_pool->db->blue_green_deployment_db_type == BLUE_GREEN_TARGET) {
 +			// Check if instance is unhealthy or has configuration changes
 +			if (next_pool->last_connect_failed ||
 +				next_pool->db->port != topology->port_num ||
 +				strcmp(next_pool->db->host, topology->endpoint) != 0) {
-+				return next_pool;
++
++				struct FailedPgPool *entry = malloc(sizeof(struct FailedPgPool));
++				if (!entry) {
++					log_error("Failed to allocate memory for FailedPgPool entry");
++					cleanup_failed_pool_entry(failed_pools);
++					return NULL;
++				}
++				list_init(&entry->head);
++				entry->pool = next_pool;
++				// Add to failed_pools list using the existing head member of PgPool
++				statlist_append(failed_pools, &entry->head);
 +			}
 +		}
 +	}
-+    return NULL;
++	return failed_pools;
 +}
 +
 +/*
@@ -358,25 +446,30 @@ index c6e5efe..eb8ded7 100644
 + * based on changes in host or port.
 + */
 +static bool check_if_new_pool_required_for_target(PgPool *target_instance_pool, TopologyData *topology) {
-+    // Check if hostname or port has changed
-+    if (strcmp(target_instance_pool->db->host, topology->endpoint) != 0 || target_instance_pool->db->port != topology->port_num) {
-+		updated_target_port_num = topology->port_num;
++	// Check if hostname or port has changed
++    if (strcmp(target_instance_pool->db->host, topology->endpoint) != 0) {
 +		// Kill existing pool for outdated target
-+		log_debug("handle_server_work: Detected a change in the green DB host or port. "
-+			"Killing the existing database connection. db_name: %s, old_host: %s, new_host: %s, old_port: %d, new_port: %d",
-+			target_instance_pool->db->name, target_instance_pool->db->host, topology->endpoint, target_instance_pool->db->port,
-+			topology->port_num);
-+		kill_database(target_instance_pool->db);
++		log_debug("handle_server_work: Detected a change in the green DB host. "
++			"Killing the existing database connection. db_name: %s, old_host: %s, new_host: %s",
++			target_instance_pool->db->name, target_instance_pool->db->host, topology->endpoint);
 +		return true;
++	} else if (target_instance_pool->db->port != topology->port_num) {
++		// Update the port for the pool before opening the connection
++		log_debug("handle_server_work: Detected a change in the green DB host. "
++			"Updating the port for db_name: %s, old_port: %d, new_port: %d",
++			target_instance_pool->db->name, target_instance_pool->db->port, topology->port_num);
++		updated_target_port_num = topology->port_num;
++		target_instance_pool->db->port = topology->port_num;
 +	}
 +
++	log_debug("handle_server_work: launch new connection for the db : %s", target_instance_pool->db->name);
 +	// reuse existing pool
 +	launch_new_connection(target_instance_pool, true);
 +	return false;
 +}
 +
 +/*
-+ * Attempts to create and initialize a new connection pool for the target instance.
++ * Attempts to create and initialize a new connection pool for the updated topology.
 + *
 + * This function calls setup_new_pool() with the given server and topology data.
 + * - Returns true if the new pool is successfully created and initialized.
@@ -386,8 +479,8 @@ index c6e5efe..eb8ded7 100644
 + */
 +
 +
-+static bool initialize_new_target_pool(PgSocket *server, TopologyData *topology) {
-+	PgPool *new_pool = setup_new_pool(server, topology, true/* for updated target pool connection*/);
++static bool initialize_new_target_pool(PgPool *parent_pool, TopologyData *topology) {
++	PgPool *new_pool = setup_new_pool(parent_pool, topology/* for updated target pool connection*/);
 +	if (new_pool == NULL) {
 +		log_debug("handle_server_work: Failed to initialize new connection pool for host '%s'. Possible issue with memory allocation, hostname parsing, or connection launch.",
 +			topology->endpoint);
@@ -397,18 +490,69 @@ index c6e5efe..eb8ded7 100644
 +	return true;
 +}
 +
-+static bool cleanup_data_and_topology(char *data, TopologyData *topology, SBuf *sbuf, PktHdr *pkt) {
-+    free(data);
-+    cleanup_topology(topology);
-+    sbuf_prepare_skip(sbuf, pkt->len);
-+    return true;
++/**
++ * handle_failed_target_pools - Replaces failed or outdated target pools with updated ones.
++ *
++ * This function iterates over a list of failed target pools (typically identified by
++ * a mismatch in endpoint or failed connection attempts) and determines whether a new
++ * pool needs to be created for each entry using the current topology information.
++ *
++ * For each failed pool that requires replacement:
++ *   - It logs the original database name and host.
++ *   - Extracts the base database name by stripping the endpoint suffix.
++ *   - Destroys the existing (failed) database connection using `kill_database`.
++ *   - Creates a new target pool with updated host/port/topology using `initialize_new_target_pool`.
++ *
++ * If any part of this process fails (e.g., memory allocation, base name extraction, or
++ * pool initialization), the function logs an error and returns false to indicate that
++ * the operation was unsuccessful. On success, it returns true.
++ *
++ * The caller must ensure that `failed_pools` is valid and correctly populated before calling.
++ *
++ * @param failed_pools  List of target pools that have failed or become outdated.
++ * @param topology      The current deployment topology containing expected endpoint and port.
++ *
++ * @return true on successful replacement of all failed pools; false if any step fails.
++ */
++
++static bool handle_failed_target_pools(struct StatList *failed_pools, TopologyData *topology) {
++	struct List *item;
++	PgPool *target_instance_pool;
++	PgPool *parent_pool;
++
++	statlist_for_each(item, failed_pools) {
++		// Get the PgPool from the item's next pointer which points to PgPool's head
++		struct FailedPgPool *failed = container_of(item, struct FailedPgPool, head);
++		target_instance_pool = failed->pool;
++
++		if (check_if_new_pool_required_for_target(target_instance_pool, topology)) {
++			parent_pool = target_instance_pool->parent_pool;
++			kill_database(target_instance_pool->db);
++			parent_pool->num_nodes--;
++
++			// Set up a new pool with the updated endpoint and topology information
++			if (!initialize_new_target_pool(parent_pool, topology)) {
++				log_error("Failed to set up connection pool. Aborting to prevent inconsistent topology state.");
++				return false;
++			}
++		}
++	}
++	return true;
++}
++
++static bool cleanup_data_and_topology(char *data, TopologyData *topology, SBuf *sbuf, PktHdr *pkt, struct StatList *failed_pools) {
++	free(data);
++	cleanup_topology(topology);
++	cleanup_failed_pool_entry(failed_pools);
++	sbuf_prepare_skip(sbuf, pkt->len);
++	return true;
 +}
 +
 +
  /* process packets on logged in connection */
  static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  {
-@@ -363,6 +720,12 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -363,6 +833,13 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
  	struct List *item, *tmp;
  	bool ignore_packet = false;
@@ -418,10 +562,11 @@ index c6e5efe..eb8ded7 100644
 +	const char *topology_parser_msg;
 +	char *data = NULL;
 +	PgDatabase *db = NULL;
++	struct StatList *failed_pools = NULL;
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +737,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +851,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case PqMsg_ReadyForQuery:
@@ -437,7 +582,7 @@ index c6e5efe..eb8ded7 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +833,38 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -461,6 +947,39 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		break;
  
  	case PqMsg_CommandComplete:
@@ -455,7 +600,7 @@ index c6e5efe..eb8ded7 100644
 +			 */
 +			log_debug("handle_server_work: switchover started retrying to get the state of Blue Green deployment, db_name: %s", server->pool->db->name);
 +			server->pool->checking_for_new_writer = false;
-+		} else if (fast_switchover && server->pool->db->is_topology_check_in_progress) {
++		} else if (fast_switchover && server->pool->db->is_topology_check_in_progress && is_topology_monitoring_job_enabled) {
 +			/*
 +			 * Topology query execution completed, but PqMsg_DataRow handler wasn't triggered.
 +			 * This means the topology query returned no results, indicating the
@@ -464,7 +609,8 @@ index c6e5efe..eb8ded7 100644
 +			 */
 +			log_warning("handle_server_work: topology query returned no results for db: %s, Disabling fast switchover.", server->pool->db->name);
 +			server->pool->db->is_topology_check_in_progress = false;
-+			fast_switchover =  false;
++			fast_switchover = false;
++			is_topology_monitoring_job_enabled = false;
 +			statlist_for_each_safe(item, &database_list, tmp) {
 +				db = container_of(item, PgDatabase, head);
 +				if (db->blue_green_deployment_db_type == BLUE_GREEN_TARGET) {
@@ -476,7 +622,7 @@ index c6e5efe..eb8ded7 100644
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
  			slog_debug(server, "COPY finished");
-@@ -545,6 +949,109 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -545,6 +1064,110 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case PqMsg_CopyData:
  	case PqMsg_DataRow:
@@ -512,22 +658,15 @@ index c6e5efe..eb8ded7 100644
 +					 * green instance is now ready to accept write operations.
 +					 */
 +					routing_traffic_to_target_complete =  true;
++					is_topology_monitoring_job_enabled = false;
 +				}
-+			} else if (strcmp(data, AVAILABLE) == 0) {
++			} else if (server->pool->db->blue_green_deployment_db_type == BLUE_GREEN_TARGET && strcmp(data, AVAILABLE) == 0) {
 +				/*
 +				 * This scenario occurs when the source instance becomes unavailable before the switchover.
 +				 * As a result, the switchover status entry in the Blue-Green Deployment metadata table remains as AVAILABLE.
 +				 * In this case, we will attempt to re-establish the closed connection and set the source_instance_down_before_switchover flag to true.
 +				 */
 +				log_debug("handle_server_work: source instance is down before the switchover need to open the new connection, recovery query ran on : db_name %s", server->pool->db->name);
-+				statlist_for_each(item, &pool_list) {
-+					next_pool = container_of(item, PgPool, head);
-+					if (!next_pool->last_connect_failed) {
-+						continue;
-+					}
-+					log_debug("handle_server_work: establishing new connection to pool: %s", next_pool->db->name);
-+					launch_new_connection(next_pool, /* evict_if_needed= */ true);
-+				}
 +				source_instance_down_before_switchover = true;
 +			} else {
 +				log_debug("handle_server_work: connected to reader (pg_is_in_recovery is '%s'). db_name: %s, Must keep polling until next server.", data, server->pool->db->name);
@@ -558,35 +697,43 @@ index c6e5efe..eb8ded7 100644
 +			// During Switchover do not let the topology job to perform any action
 +			if (strcmp(topology->status, AVAILABLE) != 0) {
 +				server->pool->db->is_topology_check_in_progress = false;
-+				return cleanup_data_and_topology(data, topology, sbuf, pkt);
++				return cleanup_data_and_topology(data, topology, sbuf, pkt, failed_pools);
 +			}
 +
 +			if (!find_target_endpoint_to_setup_connection(server, topology)) {
-+				return cleanup_data_and_topology(data, topology, sbuf, pkt);
++				return cleanup_data_and_topology(data, topology, sbuf, pkt, failed_pools);
 +			}
 +
-+			PgPool* target_instance_pool = check_if_target_has_failed_connection(topology);
-+			if (!target_instance_pool) {
-+				// Target instance has healthy connection, skipping the recovery
++			failed_pools = check_target_pools_with_failed_connection(topology);
++			if (failed_pools == NULL) {
++				cleanup_topology(topology);
++				free(data);
++				fatal("Unable to extract target pools list with failed connections from topology. "
++					"This could be due to memory allocation failure or no matching pools found.");
++			}
++
++			// All Target resource has healthy connection, skipping the recovery
++			if (statlist_empty(failed_pools)) {
 +				server->pool->db->is_topology_check_in_progress = false;
-+				return cleanup_data_and_topology(data, topology, sbuf, pkt);
++				return cleanup_data_and_topology(data, topology, sbuf, pkt, failed_pools);
 +			}
 +
-+			if (check_if_new_pool_required_for_target(target_instance_pool, topology)) {
-+				// Set up a new pool with the updated endpoint and topology information
-+				if (!initialize_new_target_pool(server, topology)) {
-+					cleanup_topology(topology);
-+					free(data);
-+					fatal("Failed to set up connection pool. Aborting to prevent inconsistent topology state.");
-+				}
++			if(!handle_failed_target_pools(failed_pools, topology)) {
++				cleanup_topology(topology);
++				free(data);
++				cleanup_failed_pool_entry(failed_pools);
++				fatal("Failed to handle and update target pools with connection issues or configuration mismatches. "
++					"This could be due to inability to extract base database names, failure in terminating existing connections, "
++					"or problems initializing new pools with updated topology. "
++					"Aborting to prevent inconsistent topology state and potential data integrity issues.");
 +			}
 +			server->pool->db->is_topology_check_in_progress = false;
-+			return cleanup_data_and_topology(data, topology, sbuf, pkt);
++			return cleanup_data_and_topology(data, topology, sbuf, pkt, failed_pools);
 +		}
  		break;
  	}
  	server->idle_tx = idle_tx;
-@@ -632,7 +1139,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -632,7 +1255,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -595,7 +742,7 @@ index c6e5efe..eb8ded7 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +1147,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +1263,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -615,7 +762,7 @@ index c6e5efe..eb8ded7 100644
  	return true;
  }
  
-@@ -754,6 +1274,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +1390,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -623,13 +770,13 @@ index c6e5efe..eb8ded7 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +1289,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +1405,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
 -		else
 +		else {
-+			if (global_writer)
++			if (global_writer && pool->db->blue_green_deployment_db_type != BLUE_GREEN_TARGET)
 +				clear_global_writer(pool);
 +
 +			// mark main pool as failed as well (the writer)
@@ -643,7 +790,7 @@ index c6e5efe..eb8ded7 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +1341,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1457,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);
@@ -654,7 +801,7 @@ index c6e5efe..eb8ded7 100644
  		disconnect_server(server, false, "connect failed");
  		break;
  	case SBUF_EV_CONNECT_OK:
-@@ -893,3 +1428,279 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -893,3 +1544,289 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		takeover_login_failed();
  	return res;
  }
@@ -836,9 +983,8 @@ index c6e5efe..eb8ded7 100644
 + *
 + * This function creates and configures a new PgPool instance using the provided topology data.
 + *
-+ * @param server The server socket associated with the current connection.
++ * @param pool_to_configure The pool associated with the current connection.
 + * @param topology A pointer to the TopologyData structure containing parsed topology information.
-+ * @param hostname The hostname for the new pool, derived from the topology endpoint.
 + *
 + * @return A pointer to the newly created PgPool if successful, or NULL if an error occurred.
 + *
@@ -859,41 +1005,52 @@ index c6e5efe..eb8ded7 100644
 + * @see new_pool_from_db()
 + * @see launch_new_connection()
 + */
-+PgPool* setup_new_pool(PgSocket *server, TopologyData *topology, bool is_replacement_pool) {
++PgPool* setup_new_pool(PgPool *pool_to_configure, TopologyData *topology) {
 +	/* Make a copy of endpoint for hostname */
 +	char* hostname = strdup(topology->endpoint);
++	char* dbname_with_endpoint = NULL;
++	PgPool *new_pool = NULL;
 +	if (hostname == NULL) {
-+		log_debug("strdup: no mem for hostname");
++		log_warning("strdup: no mem for hostname");
 +		return NULL;
 +	}
 +	if (!strtok(topology->endpoint, ".")) {
-+		log_debug("could not parse hostname present in topology, hostname to parse: %s", topology->endpoint);
++		log_warning("could not parse hostname present in topology, hostname to parse: %s", topology->endpoint);
 +		free(hostname);
 +		return NULL;
 +	}
-+    PgPool *new_pool = new_pool_from_db(server->pool->db, topology->endpoint, hostname, topology->port_num);
++
++	dbname_with_endpoint = concat_multiple_strings(3, pool_to_configure->db->name, "_", topology->endpoint);
++
++	if (!dbname_with_endpoint) {
++		log_warning("Memory allocation failed while joining dbname and endpoint name");
++		free(hostname);
++		return NULL;
++	}
++
++	new_pool = new_pool_from_db(pool_to_configure->db, dbname_with_endpoint, hostname, topology->port_num);
 +    if (!new_pool) {
++		free(dbname_with_endpoint);
 +		free(hostname);
 +		return NULL;
 +    }
 +
-+	if (is_replacement_pool) {
-+		new_pool->parent_pool = server->pool->parent_pool;
-+		new_pool->parent_pool->global_writer = server->pool->parent_pool->global_writer;
-+	} else {
-+		new_pool->parent_pool = server->pool;
-+		new_pool->parent_pool->global_writer = server->pool;
-+	}
-+    new_pool->db->topology_query = strdup(server->pool->db->topology_query);
++	new_pool->parent_pool = pool_to_configure;
++	new_pool->parent_pool->global_writer = pool_to_configure;
++	new_pool->db->topology_query = strdup(pool_to_configure->db->topology_query);
 +	if (new_pool->db->topology_query == NULL) {
-+		log_debug("strdup: no mem for topology_query");
++		log_warning("strdup: no mem for topology_query");
++		free(dbname_with_endpoint);
++		free(hostname);
 +		return NULL;
 +	}
 +
-+    if (server->pool->db->recovery_query) {
-+		new_pool->db->recovery_query = strdup(server->pool->db->recovery_query);
++    if (pool_to_configure->db->recovery_query) {
++		new_pool->db->recovery_query = strdup(pool_to_configure->db->recovery_query);
 +		if (new_pool->db->recovery_query == NULL) {
-+			log_debug("strdup: no mem for recovery_query");
++			log_warning("strdup: no mem for recovery_query");
++			free(dbname_with_endpoint);
++			free(hostname);
 +			return NULL;
 +		}
 +		if (strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0) {
@@ -903,9 +1060,9 @@ index c6e5efe..eb8ded7 100644
 +		}
 +    }
 +
-+    launch_new_connection(new_pool, true);
-+    server->pool->num_nodes++;
-+
++	launch_new_connection(new_pool, true);
++	pool_to_configure->num_nodes++;
++	free(dbname_with_endpoint);
 +	free(hostname);
 +	return new_pool;
 +}
@@ -934,4 +1091,3 @@ index c6e5efe..eb8ded7 100644
 +		free(topology);
 +	}
 +}
-\ No newline at end of file

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..49d2a6c 100644
+index c6e5efe..116e344 100644
 --- a/src/server.c
 +++ b/src/server.c
 @@ -27,6 +27,123 @@
@@ -139,7 +139,7 @@ index c6e5efe..49d2a6c 100644
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +256,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +256,28 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
  		case PqMsg_ReadyForQuery:
  		case PqMsg_ParameterStatus:
@@ -150,13 +150,25 @@ index c6e5efe..49d2a6c 100644
  		case PqMsg_ErrorResponse:
  			/* log & ignore errors */
  			log_server_error("S: error while executing exec_on_query", pkt);
-+			// require topology table to exist in the cluster if using
-+			if (fast_switchover)
++			/*
++			 * require topology table to exist in the cluster if using fast switchover.
++			 */
++			if (fast_switchover && server->pool->db->recovery_query && is_cluster_endpoint(server->pool->db->host)) {
++				/*
++				 * During blue-green deployment, the fast switchover feature's topology query may fail if the cluster is not part of the deployment.
++				 * To handle this scenario, if the topology query encounters an error, PgBouncer will not crash; instead, it will disable the fast switchover feature.
++				 * Once the customer sets up the blue-green deployment and performs a RELOAD, the fast switchover feature will be re-enabled
++				 * if the topology query successfully finds the node during execution.
++				 */
++				fast_switchover = false;
++			} else if (fast_switchover) {
 +				fatal("does the topology table exist?");
++			}
++
  		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +279,71 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +291,88 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -196,6 +208,23 @@ index c6e5efe..49d2a6c 100644
 +				free(data);
 +				fatal("strdup: no mem for hostname");
 +			}
++			if (fast_switchover && server->pool->db->recovery_query) {
++				/*
++				 * Blue-Green Deployment Fast Switchover:
++				 * Open connections only to the specified endpoint and its green counterpart; skip all other endpoints.
++				 * Connection Pool Handling:
++				 * - For writer endpoints (e.g., used with PgBouncer), ensure a connection is established to the corresponding writer on the green cluster.
++				 * - For reader endpoints, establish a connection to the equivalent reader on the green cluster.
++				 * - Apply the same logic for custom-defined endpoints.
++				 */
++				bool should_continue = setup_connection_pool_based_on_endpoint_type(server->pool->db->host, hostname);
++				if (!should_continue) {
++					free(data);
++					free(hostname);
++					sbuf_prepare_skip(sbuf, pkt->len);
++					return true;
++				}
++			}
 +
 +			if (!strtok(endpoint, ".")) {
 +				free(data);
@@ -228,7 +257,7 @@ index c6e5efe..49d2a6c 100644
  	case PqMsg_ErrorResponse:
  		/*
  		 * If we cannot log into the server, then we drop all clients
-@@ -201,7 +393,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -201,7 +422,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -289,7 +318,7 @@ index c6e5efe..49d2a6c 100644
  
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -363,6 +608,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -363,6 +637,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
  	struct List *item, *tmp;
  	bool ignore_packet = false;
@@ -298,7 +327,7 @@ index c6e5efe..49d2a6c 100644
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +621,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +650,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case PqMsg_ReadyForQuery:
@@ -314,7 +343,7 @@ index c6e5efe..49d2a6c 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +717,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -461,6 +746,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		break;
  
  	case PqMsg_CommandComplete:
@@ -337,7 +366,7 @@ index c6e5efe..49d2a6c 100644
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
  			slog_debug(server, "COPY finished");
-@@ -545,6 +817,53 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -545,6 +846,53 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case PqMsg_CopyData:
  	case PqMsg_DataRow:
@@ -391,7 +420,7 @@ index c6e5efe..49d2a6c 100644
  		break;
  	}
  	server->idle_tx = idle_tx;
-@@ -632,7 +951,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -632,7 +980,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -400,7 +429,7 @@ index c6e5efe..49d2a6c 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +959,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +988,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -420,7 +449,7 @@ index c6e5efe..49d2a6c 100644
  	return true;
  }
  
-@@ -754,6 +1086,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +1115,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -428,7 +457,7 @@ index c6e5efe..49d2a6c 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +1101,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +1130,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -448,7 +477,7 @@ index c6e5efe..49d2a6c 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +1153,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1182,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,13 +1,15 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..b2611e4 100644
+index c6e5efe..d2a6780 100644
 --- a/src/server.c
 +++ b/src/server.c
-@@ -27,6 +27,123 @@
+@@ -27,6 +27,125 @@
  
  #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
  
 +bool routing_traffic_to_target_complete = false;
 +bool source_instance_down_before_switchover = false;
++/* Stores the new port number set by customer for the green (target) instance during Blue-Green Deployment. */
++int updated_target_port_num = 0;
 +
 +/**
 + * Extracts and processes query result data from a packet into a tab-separated string.
@@ -126,7 +128,7 @@ index c6e5efe..b2611e4 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -122,6 +239,9 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -122,6 +241,9 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
@@ -136,7 +138,7 @@ index c6e5efe..b2611e4 100644
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +253,28 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +255,30 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
  		case PqMsg_ReadyForQuery:
  		case PqMsg_ParameterStatus:
@@ -157,6 +159,8 @@ index c6e5efe..b2611e4 100644
 +				 * Once the customer sets up the blue-green deployment and performs a RELOAD, the fast switchover feature will be re-enabled
 +				 * if the topology query successfully finds the node during execution.
 +				 */
++				log_warning("Fast switchover disabled: topology query failed. The current cluster node may not be part of a Blue-Green deployment. "
++					"Feature will be re-enabled after a successful topology query following RELOAD.");
 +				fast_switchover = false;
 +			} else if (fast_switchover) {
 +				fatal("does the topology table exist?");
@@ -165,7 +169,7 @@ index c6e5efe..b2611e4 100644
  		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +288,53 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +292,53 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -199,7 +203,7 @@ index c6e5efe..b2611e4 100644
 +				}
 +
 +				/* Set up a new connection pool based on topology data. */
-+				if (setup_new_pool(server, topology) == NULL) {
++				if (setup_new_pool(server, topology, false/* for freshly pool connections*/) == NULL) {
 +					// Handle setup failure if needed
 +					log_debug("Failed to initialize new connection pool for host '%s'. Possible issue with memory allocation, hostname parsing, or connection launch.",
 +						topology->endpoint);
@@ -219,7 +223,7 @@ index c6e5efe..b2611e4 100644
  	case PqMsg_ErrorResponse:
  		/*
  		 * If we cannot log into the server, then we drop all clients
-@@ -201,7 +384,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -201,7 +388,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -254,7 +258,7 @@ index c6e5efe..b2611e4 100644
 +				 * Here, we monitor the startup status of the new blue instance and the 'routing_traffic_to_target_complete' flag.
 +				 * Once both conditions are met, we disable the fast switchover feature.
 +				 */
-+				log_debug("Once the switchover is completed for DB : %s, disabling the fast switchover and reverting PgBouncer to standard connection pooling mode.", server->pool->db->name);
++				log_warning("Once the switchover is completed for DB : %s, disabling the fast switchover and reverting PgBouncer to standard connection pooling mode.", server->pool->db->name);
 +				if (!server->pool->parent_pool) {
 +					server->pool->parent_pool = server->pool;
 +				}
@@ -271,7 +275,7 @@ index c6e5efe..b2611e4 100644
 +				 * In this case, PgBouncer will not crash. Instead, it will disable the fast switchover feature and revert to the standard PgBouncer behavior.
 +				 */
 +				fast_switchover = false;
-+				log_debug("topology_query did not find at least 2 nodes to use Blue Green Deployment fast switchover for DB: '%s'. PgBouncer reverting to standard connection pooling mode.", server->pool->db->name);
++				log_warning("topology_query did not find at least 2 nodes to use Blue Green Deployment fast switchover for DB: '%s'. PgBouncer reverting to standard connection pooling mode.", server->pool->db->name);
 +			} else {
 +				fatal("topology_query did not find at least 2 nodes to use fast switchover in DB: '%s'. Is the topology table populated with entries?", server->pool->db->name);
 +			}
@@ -280,7 +284,7 @@ index c6e5efe..b2611e4 100644
  
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -352,6 +588,24 @@ int user_client_max_connections(PgGlobalUser *user)
+@@ -352,6 +592,123 @@ int user_client_max_connections(PgGlobalUser *user)
  		return user->max_user_client_connections;
  }
  
@@ -301,20 +305,123 @@ index c6e5efe..b2611e4 100644
 +			((strcmp(data, AVAILABLE) == 0) && (db_type == DEFAULT));
 +}
 +
++static bool find_target_endpoint_to_setup_connection(PgSocket *server, TopologyData *topology) {
++	// If the role is still source — skip processing
++	if (strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0) {
++		return false;
++	}
++	/*
++	 * Blue-Green Deployment Fast Switchover:
++	 * Open connections only to the specified endpoint and its green counterpart; skip all other endpoints.
++	 * Connection Pool Handling:
++	 * - For writer endpoints (e.g., used with PgBouncer), ensure a connection is established to the corresponding writer on the green cluster.
++	 * - For reader endpoints, establish a connection to the equivalent reader on the green cluster.
++	 * - Apply the same logic for custom-defined endpoints.
++	 */
++	return setup_connection_pool_based_on_endpoint_type(server->pool->db->host, &topology->endpoint);
++}
++
++/*
++ * Checks if the Blue-Green target instance has a failed connection or configuration mismatch.
++ *
++ * This function scans through the pool list to find the target (green) pool.
++ * It returns the target pool if any of the following conditions are true:
++ * - The last connection attempt to the target failed
++ * - The configured port number differs from the expected topology port
++ * - The configured host does not match the expected topology endpoint
++ *
++ * Returns NULL if the target instance is healthy and properly configured.
++ */
++
++
++static PgPool* check_if_target_has_failed_connection(TopologyData *topology) {
++	struct List *item;
++	PgPool *next_pool = NULL;
++
++	// Look through pool list for target instance's pool
++	statlist_for_each(item, &pool_list) {
++		next_pool = container_of(item, PgPool, head);
++		if (next_pool->db->blue_green_deployment_db_type == BLUE_GREEN_TARGET) {
++			// Check if instance is unhealthy or has configuration changes
++			if (next_pool->last_connect_failed ||
++				next_pool->db->port != topology->port_num ||
++				strcmp(next_pool->db->host, topology->endpoint) != 0) {
++				return next_pool;
++			}
++		}
++	}
++    return NULL;
++}
++
++/*
++ * Check if a new pool is required for the Blue-Green target instance
++ * based on changes in host or port.
++ */
++static bool check_if_new_pool_required_for_target(PgPool *target_instance_pool, TopologyData *topology) {
++    // Check if hostname or port has changed
++    if (strcmp(target_instance_pool->db->host, topology->endpoint) != 0 || target_instance_pool->db->port != topology->port_num) {
++		updated_target_port_num = topology->port_num;
++		// Kill existing pool for outdated target
++		log_debug("handle_server_work: Detected a change in the green DB host or port. "
++			"Killing the existing database connection. db_name: %s, old_host: %s, new_host: %s, old_port: %d, new_port: %d",
++			target_instance_pool->db->name, target_instance_pool->db->host, topology->endpoint, target_instance_pool->db->port,
++			topology->port_num);
++		kill_database(target_instance_pool->db);
++		return true;
++	}
++
++	// reuse existing pool
++	launch_new_connection(target_instance_pool, true);
++	return false;
++}
++
++/*
++ * Attempts to create and initialize a new connection pool for the target instance.
++ *
++ * This function calls setup_new_pool() with the given server and topology data.
++ * - Returns true if the new pool is successfully created and initialized.
++ * - Returns false if pool creation fails, logging the failure reason.
++ *
++ * On success, the new pool inherits the parent pool from the server's existing pool.
++ */
++
++
++static bool initialize_new_target_pool(PgSocket *server, TopologyData *topology) {
++	PgPool *new_pool = setup_new_pool(server, topology, true/* for updated target pool connection*/);
++	if (new_pool == NULL) {
++		log_debug("handle_server_work: Failed to initialize new connection pool for host '%s'. Possible issue with memory allocation, hostname parsing, or connection launch.",
++			topology->endpoint);
++		return false;
++	}
++	log_debug("handle_server_work: Successfully initialized new database connection. db_name: %s, port number: %d", new_pool->db->name, new_pool->db->port);
++	return true;
++}
++
++static bool cleanup_data_and_topology(char *data, TopologyData *topology, SBuf *sbuf, PktHdr *pkt) {
++    free(data);
++    cleanup_topology(topology);
++    sbuf_prepare_skip(sbuf, pkt->len);
++    return true;
++}
++
 +
  /* process packets on logged in connection */
  static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  {
-@@ -363,6 +617,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -363,6 +720,12 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
  	struct List *item, *tmp;
  	bool ignore_packet = false;
 +	bool res = false;
-+	PgPool *next_pool;
++	PgPool *next_pool = NULL;
++	TopologyData *topology = NULL;
++	const char *topology_parser_msg;
++	char *data = NULL;
++	PgDatabase *db = NULL;
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +630,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +737,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case PqMsg_ReadyForQuery:
@@ -330,7 +437,7 @@ index c6e5efe..b2611e4 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +726,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -461,6 +833,38 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		break;
  
  	case PqMsg_CommandComplete:
@@ -348,12 +455,28 @@ index c6e5efe..b2611e4 100644
 +			 */
 +			log_debug("handle_server_work: switchover started retrying to get the state of Blue Green deployment, db_name: %s", server->pool->db->name);
 +			server->pool->checking_for_new_writer = false;
++		} else if (fast_switchover && server->pool->db->is_topology_check_in_progress) {
++			/*
++			 * Topology query execution completed, but PqMsg_DataRow handler wasn't triggered.
++			 * This means the topology query returned no results, indicating the
++			 * topology table is empty. Since fast switchover requires topology
++			 * data to function properly, so we must disable this feature now.
++			 */
++			log_warning("handle_server_work: topology query returned no results for db: %s, Disabling fast switchover.", server->pool->db->name);
++			server->pool->db->is_topology_check_in_progress = false;
++			fast_switchover =  false;
++			statlist_for_each_safe(item, &database_list, tmp) {
++				db = container_of(item, PgDatabase, head);
++				if (db->blue_green_deployment_db_type == BLUE_GREEN_TARGET) {
++					kill_database(db);
++				}
++			}
 +		}
 +
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
  			slog_debug(server, "COPY finished");
-@@ -545,6 +826,61 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -545,6 +949,109 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case PqMsg_CopyData:
  	case PqMsg_DataRow:
@@ -402,7 +525,7 @@ index c6e5efe..b2611e4 100644
 +					if (!next_pool->last_connect_failed) {
 +						continue;
 +					}
-+					log_debug("launch_recheck: establishing new connection to pool: %s", next_pool->db->name);
++					log_debug("handle_server_work: establishing new connection to pool: %s", next_pool->db->name);
 +					launch_new_connection(next_pool, /* evict_if_needed= */ true);
 +				}
 +				source_instance_down_before_switchover = true;
@@ -411,11 +534,59 @@ index c6e5efe..b2611e4 100644
 +			}
 +			server->pool->checking_for_new_writer = false;
 +			free(data);
++		} else if (fast_switchover && server->pool->db->is_topology_check_in_progress) {
++			/*
++			 * If the target instance pool is in a failed state,
++			 * 1. Parse the topology data from the current packet.
++			 * 2. If the role is BLUE_GREEN_DEPLOYMENT_SOURCE, skip processing the packet.
++			 * 3. Allocate memory for the hostname.
++			 * 4. Set up the connection pool based on the endpoint type.
++			 * 5. If the port has changed for the target pool, update the port num
++			 * 6. If the hostname has changed, kill the existing database.
++			 * 7. Create a new pool using the updated topology data.
++			 * 8. Set the new pool's parent pool to the server's parent pool.
++			 * 9. Open a new connection for the target pool
++			 */
++			data = query_data(pkt);
++			// Parse the topology data received from the metadata query
++			topology_parser_msg = parse_topology_data(server, data, &topology);
++			if (topology_parser_msg) {
++				free(data);
++				fatal("failed while parsing the topology data. Error msg : %s", topology_parser_msg);
++			}
++
++			// During Switchover do not let the topology job to perform any action
++			if (strcmp(topology->status, AVAILABLE) != 0) {
++				server->pool->db->is_topology_check_in_progress = false;
++				return cleanup_data_and_topology(data, topology, sbuf, pkt);
++			}
++
++			if (!find_target_endpoint_to_setup_connection(server, topology)) {
++				return cleanup_data_and_topology(data, topology, sbuf, pkt);
++			}
++
++			PgPool* target_instance_pool = check_if_target_has_failed_connection(topology);
++			if (!target_instance_pool) {
++				// Target instance has healthy connection, skipping the recovery
++				server->pool->db->is_topology_check_in_progress = false;
++				return cleanup_data_and_topology(data, topology, sbuf, pkt);
++			}
++
++			if (check_if_new_pool_required_for_target(target_instance_pool, topology)) {
++				// Set up a new pool with the updated endpoint and topology information
++				if (!initialize_new_target_pool(server, topology)) {
++					cleanup_topology(topology);
++					free(data);
++					fatal("Failed to set up connection pool. Aborting to prevent inconsistent topology state.");
++				}
++			}
++			server->pool->db->is_topology_check_in_progress = false;
++			return cleanup_data_and_topology(data, topology, sbuf, pkt);
 +		}
  		break;
  	}
  	server->idle_tx = idle_tx;
-@@ -632,7 +968,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -632,7 +1139,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -424,7 +595,7 @@ index c6e5efe..b2611e4 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +976,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +1147,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -444,7 +615,7 @@ index c6e5efe..b2611e4 100644
  	return true;
  }
  
-@@ -754,6 +1103,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +1274,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -452,7 +623,7 @@ index c6e5efe..b2611e4 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +1118,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +1289,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -472,7 +643,7 @@ index c6e5efe..b2611e4 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +1170,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1341,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);
@@ -483,7 +654,7 @@ index c6e5efe..b2611e4 100644
  		disconnect_server(server, false, "connect failed");
  		break;
  	case SBUF_EV_CONNECT_OK:
-@@ -893,3 +1257,262 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -893,3 +1428,267 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		takeover_login_failed();
  	return res;
  }
@@ -676,7 +847,7 @@ index c6e5efe..b2611e4 100644
 + * @see new_pool_from_db()
 + * @see launch_new_connection()
 + */
-+PgPool* setup_new_pool(PgSocket *server, TopologyData *topology) {
++PgPool* setup_new_pool(PgSocket *server, TopologyData *topology, bool is_replacement_pool) {
 +	/* Make a copy of endpoint for hostname */
 +	char* hostname = strdup(topology->endpoint);
 +	if (hostname == NULL) {
@@ -694,8 +865,13 @@ index c6e5efe..b2611e4 100644
 +		return NULL;
 +    }
 +
-+    new_pool->parent_pool = server->pool;
-+    new_pool->parent_pool->global_writer = server->pool;
++	if (is_replacement_pool) {
++		new_pool->parent_pool = server->pool->parent_pool;
++		new_pool->parent_pool->global_writer = server->pool->parent_pool->global_writer;
++	} else {
++		new_pool->parent_pool = server->pool;
++		new_pool->parent_pool->global_writer = server->pool;
++	}
 +    new_pool->db->topology_query = strdup(server->pool->db->topology_query);
 +	if (new_pool->db->topology_query == NULL) {
 +		log_debug("strdup: no mem for topology_query");

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,12 +1,13 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..ef0cdb3 100644
+index c6e5efe..49d2a6c 100644
 --- a/src/server.c
 +++ b/src/server.c
-@@ -27,6 +27,122 @@
+@@ -27,6 +27,123 @@
  
  #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
  
 +bool routing_traffic_to_target_complete = false;
++bool source_instance_down_before_switchover = false;
 +
 +/**
 + * Extracts and processes query result data from a packet into a tab-separated string.
@@ -125,7 +126,7 @@ index c6e5efe..ef0cdb3 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -122,6 +238,12 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -122,6 +239,12 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
@@ -138,7 +139,7 @@ index c6e5efe..ef0cdb3 100644
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +255,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +256,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
  		case PqMsg_ReadyForQuery:
  		case PqMsg_ParameterStatus:
@@ -155,7 +156,7 @@ index c6e5efe..ef0cdb3 100644
  		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +278,71 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +279,71 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -227,7 +228,7 @@ index c6e5efe..ef0cdb3 100644
  	case PqMsg_ErrorResponse:
  		/*
  		 * If we cannot log into the server, then we drop all clients
-@@ -201,7 +392,42 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -201,7 +393,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -238,20 +239,38 @@ index c6e5efe..ef0cdb3 100644
 +			if (!res)
 +				disconnect_server(server, false, "exec_on_connect query failed");
 +			break;
-+		} else if (fast_switchover && server->pool->db->recovery_query && routing_traffic_to_target_complete) {
-+			/*
-+			 * After the switchover is completed, we set 'routing_traffic_to_target_complete' to true in 'handle_server_work'.
-+			 * Once DNS resolution is complete for the target instance, the new DNS becomes available for queries.
-+			 * Here, we monitor the startup status of the new blue instance and the 'routing_traffic_to_target_complete' flag.
-+			 * Once both conditions are met, we disable the fast switchover feature.
-+			 */
-+			log_debug("Once the switchover is completed for DB : %s, disabling the fast switchover and reverting PgBouncer to standard connection pooling mode.", server->pool->db->name);
-+			if (!server->pool->parent_pool) {
-+				server->pool->parent_pool = server->pool;
++		} else if (fast_switchover && source_instance_down_before_switchover && server->pool->db->recovery_query) {
++			if (server->pool->db->is_source_db) {
++				/*
++				 * This scenario occurs when the source instance was down before the switchover and has now become available.
++				 * During the handle server work, we monitor the metadata status. If the metadata entry shows AVAILABLE,
++				 * it indicates that the database connection was not dropped due to the switchover.
++				 * In this case, we wait for the source instance to come back online. Once it is available,
++				 * we reset the global writer to the source instance.
++				 */
++				log_debug("Setting the global writer once the source instance comes up : db_name %s", server->pool->db->name);
++				if (!server->pool->parent_pool) {
++					server->pool->parent_pool = server->pool;
++				}
++				server->pool->parent_pool->global_writer = server->pool;
 +			}
-+			server->pool->parent_pool->global_writer = server->pool;
-+			fast_switchover = false;
-+			routing_traffic_to_target_complete = false;
++			source_instance_down_before_switchover = false;
++		} else if (fast_switchover && server->pool->db->recovery_query && routing_traffic_to_target_complete) {
++			if (server->pool->db->is_source_db) {
++				/*
++				 * After the switchover is completed, we set 'routing_traffic_to_target_complete' to true in 'handle_server_work'.
++				 * Once DNS resolution is complete for the target instance, the new DNS becomes available for queries.
++				 * Here, we monitor the startup status of the new blue instance and the 'routing_traffic_to_target_complete' flag.
++				 * Once both conditions are met, we disable the fast switchover feature.
++				 */
++				log_debug("Once the switchover is completed for DB : %s, disabling the fast switchover and reverting PgBouncer to standard connection pooling mode.", server->pool->db->name);
++				if (!server->pool->parent_pool) {
++					server->pool->parent_pool = server->pool;
++				}
++				server->pool->parent_pool->global_writer = server->pool;
++				fast_switchover = false;
++				routing_traffic_to_target_complete = false;
++			}
 +		}
 +
 +		if (server->pool->db->topology_query && server->pool->initial_writer_endpoint && server->pool->num_nodes < 2) {
@@ -270,15 +289,16 @@ index c6e5efe..ef0cdb3 100644
  
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -363,6 +589,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -363,6 +608,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
  	struct List *item, *tmp;
  	bool ignore_packet = false;
 +	bool res = false;
++	PgPool *next_pool;
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +601,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +621,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case PqMsg_ReadyForQuery:
@@ -294,7 +314,7 @@ index c6e5efe..ef0cdb3 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +697,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -461,6 +717,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		break;
  
  	case PqMsg_CommandComplete:
@@ -317,7 +337,7 @@ index c6e5efe..ef0cdb3 100644
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
  			slog_debug(server, "COPY finished");
-@@ -545,6 +797,37 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -545,6 +817,53 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case PqMsg_CopyData:
  	case PqMsg_DataRow:
@@ -346,6 +366,22 @@ index c6e5efe..ef0cdb3 100644
 +				if (server->pool->db->recovery_query) {
 +					routing_traffic_to_target_complete =  true;
 +				}
++			} else if (strcmp(data, AVAILABLE) == 0) {
++				/*
++				 * This scenario occurs when the source instance becomes unavailable before the switchover.
++				 * As a result, the switchover status entry in the Blue-Green Deployment metadata table remains as AVAILABLE.
++				 * In this case, we will attempt to re-establish the closed connection and set the source_instance_down_before_switchover flag to true.
++				 */
++				log_debug("handle_server_work: source instance is down before the switchover need to open the new connection, recovery query ran on : db_name %s", server->pool->db->name);
++				statlist_for_each(item, &pool_list) {
++					next_pool = container_of(item, PgPool, head);
++					if (!next_pool->last_connect_failed) {
++						continue;
++					}
++					log_debug("launch_recheck: establishing new connection to pool: %s", next_pool->db->name);
++					launch_new_connection(next_pool, /* evict_if_needed= */ true);
++				}
++				source_instance_down_before_switchover = true;
 +			} else {
 +				log_debug("handle_server_work: connected to reader (pg_is_in_recovery is '%s'). db_name: %s, Must keep polling until next server.", data, server->pool->db->name);
 +			}
@@ -355,7 +391,7 @@ index c6e5efe..ef0cdb3 100644
  		break;
  	}
  	server->idle_tx = idle_tx;
-@@ -632,7 +915,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -632,7 +951,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -364,7 +400,7 @@ index c6e5efe..ef0cdb3 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +923,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +959,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -384,7 +420,7 @@ index c6e5efe..ef0cdb3 100644
  	return true;
  }
  
-@@ -754,6 +1050,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +1086,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -392,7 +428,7 @@ index c6e5efe..ef0cdb3 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +1065,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +1101,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -412,7 +448,7 @@ index c6e5efe..ef0cdb3 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +1117,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1153,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,11 +1,13 @@
 diff --git a/src/server.c b/src/server.c
-index 4a4bbb7..7632738 100644
+index c6e5efe..c46ef7b 100644
 --- a/src/server.c
 +++ b/src/server.c
-@@ -27,6 +27,44 @@
+@@ -27,6 +27,46 @@
  
  #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
  
++bool routing_traffic_to_target_complete = false;
++
 +/*
 +* Returns the query data from the server. This must be freed.
 +*/
@@ -47,8 +49,8 @@ index 4a4bbb7..7632738 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -122,6 +160,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
-	const char *msg;
+@@ -122,6 +162,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
 +	char *data = NULL;
@@ -56,24 +58,24 @@ index 4a4bbb7..7632738 100644
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +173,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +175,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
-		case PqMsg_ReadyForQuery:
-		case PqMsg_ParameterStatus:
+ 		case PqMsg_ReadyForQuery:
+ 		case PqMsg_ParameterStatus:
 +		case PqMsg_DataRow:
-			/* handle them below */
+ 			/* handle them below */
  			break;
-
-		case PqMsg_ErrorResponse:
-			/* log & ignore errors */
+ 
+ 		case PqMsg_ErrorResponse:
+ 			/* log & ignore errors */
  			log_server_error("S: error while executing exec_on_query", pkt);
 +			// require topology table to exist in the cluster if using
 +			if (fast_switchover)
 +				fatal("does the topology table exist?");
-		/* fallthrough */
+ 		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +196,38 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +198,41 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -97,6 +99,9 @@ index 4a4bbb7..7632738 100644
 +					new_pool->parent_pool = server->pool;
 +					new_pool->parent_pool->global_writer = server->pool;
 +					new_pool->db->topology_query = strdup(server->pool->db->topology_query);
++					if (server->pool->db->recovery_query) {
++						new_pool->db->recovery_query = strdup(server->pool->db->recovery_query);
++					}
 +					launch_new_connection(new_pool, true);
 +					server->pool->num_nodes++;
 +				}
@@ -109,10 +114,10 @@ index 4a4bbb7..7632738 100644
 +		sbuf_prepare_skip(sbuf, pkt->len);
 +		return true;
 +
-	case PqMsg_ErrorResponse:
-		/*
-		 * If we cannot log into the server, then we drop all clients
-@@ -201,8 +277,20 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 	case PqMsg_ErrorResponse:
+ 		/*
+ 		 * If we cannot log into the server, then we drop all clients
+@@ -201,7 +282,42 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -123,28 +128,50 @@ index 4a4bbb7..7632738 100644
 +			if (!res)
 +				disconnect_server(server, false, "exec_on_connect query failed");
 +			break;
- 		}
- 
-+		if (server->pool->db->topology_query && server->pool->initial_writer_endpoint && server->pool->num_nodes < 2) {
-+			fatal("topology_query did not find at least 2 nodes to use fast switchovers in DB: '%s'. Is the topology table populated with entries?", server->pool->db->name);
++		} else if (fast_switchover && server->pool->db->recovery_query && routing_traffic_to_target_complete) {
++			/*
++			 * After the switchover is completed, we set 'routing_traffic_to_target_complete' to true in 'handle_server_work'.
++			 * Once DNS resolution is complete for the target instance, the new DNS becomes available for queries.
++			 * Here, we monitor the startup status of the new blue instance and the 'routing_traffic_to_target_complete' flag.
++			 * Once both conditions are met, we disable the fast switchover feature.
++			 */
++			log_debug("Once the switchover is completed for DB : %s, disabling the fast switchover and reverting PgBouncer to standard connection pooling mode.", server->pool->db->name);
++			if (!server->pool->parent_pool) {
++				server->pool->parent_pool = server->pool;
++			}
++			server->pool->parent_pool->global_writer = server->pool;
++			fast_switchover = false;
++			routing_traffic_to_target_complete = false;
 +		}
-+		server->pool->initial_writer_endpoint = false;
 +
++		if (server->pool->db->topology_query && server->pool->initial_writer_endpoint && server->pool->num_nodes < 2) {
++			if (server->pool->db->recovery_query) {
++				/*
++				 * If Blue-Green Deployment fast switchover is configured on an instance/cluster node without actually creating a Blue-Green Deployment, the metadata table will return no nodes.
++				 * In this case, PgBouncer will not crash. Instead, it will disable the fast switchover feature and revert to the standard PgBouncer behavior.
++				 */
++				fast_switchover = false;
++				log_debug("topology_query did not find at least 2 nodes to use Blue Green Deployment fast switchover for DB: '%s'. PgBouncer reverting to standard connection pooling mode.", server->pool->db->name);
++			} else {
++				fatal("topology_query did not find at least 2 nodes to use fast switchover in DB: '%s'. Is the topology table populated with entries?", server->pool->db->name);
++			}
+ 		}
++		server->pool->initial_writer_endpoint = false;
+ 
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
- 		server->ready = true;
-@@ -363,6 +451,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -363,6 +479,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
-	struct List *item, *tmp;
-	bool ignore_packet = false;
+ 	struct List *item, *tmp;
+ 	bool ignore_packet = false;
 +	bool res = false;
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +463,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +491,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
-	case PqMsg_ReadyForQuery:
+ 	case PqMsg_ReadyForQuery:
 +		/*
 +		 * Discard topology data without sending to the client is finished. Resume regular
 +		 * client/server communication.
@@ -157,25 +184,33 @@ index 4a4bbb7..7632738 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +559,14 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
-		break;
-
-	case PqMsg_CommandComplete:
+@@ -461,6 +587,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 		break;
+ 
+ 	case PqMsg_CommandComplete:
 +		/*
 +		 * In the process of discarding topology data without sending to the client.
 +		 */
 +		if (server->pool->collect_datarows) {
 +			sbuf_prepare_skip(sbuf, pkt->len);
 +			return true;
++		} else if (fast_switchover && server->pool->db->recovery_query && server->pool->checking_for_new_writer && server->state != SV_TESTED) {
++			/*
++			 * This handles a corner case where the recovery query did not return any data rows for any reason.
++			 * To keep searching for the new writer, we set `checking_for_new_writer` to false for this pool,
++			 * allowing the recovery query to run again through this pool.
++			 */
++			log_debug("handle_server_work: switchover started retrying to get the state of Blue Green deployment, db_name: %s", server->pool->db->name);
++			server->pool->checking_for_new_writer = false;
 +		}
 +
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
-			slog_debug(server, "COPY finished");
-@@ -545,6 +651,29 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 			slog_debug(server, "COPY finished");
+@@ -545,6 +687,37 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
-	case PqMsg_CopyData:
-	case PqMsg_DataRow:
+ 	case PqMsg_CopyData:
+ 	case PqMsg_DataRow:
 +		/*
 +		 * These are the rows returned from the topology query that are discarded.
 +		 */
@@ -184,7 +219,12 @@ index 4a4bbb7..7632738 100644
 +			return true;
 +		} else if (fast_switchover && server->pool->checking_for_new_writer && server->state != SV_TESTED) {
 +			char *data = query_data(pkt);
-+			if (strcmp(data, "f") == 0) {
++			/*
++			 * Once the switchover begins, the recovery query will run on the target instance to retrieve the switchover status from the metadata table.
++			 * When the status changes to either SWITCHOVER_IN_POST_PROCESSING or SWITCHOVER_COMPLETED,
++			 * it indicates that the target instance is ready for accepting the writes, and we can safely update the global writer to point to the target instance.
++			 */
++			if (strcmp(data, "f") == 0 || ((strcmp(data, SWITCHOVER_IN_POST_PROCESSING) == 0) || (strcmp(data, SWITCHOVER_COMPLETED) == 0))) {
 +				log_debug("handle_server_work: connected to writer (pg_is_in_recovery is '%s'): db_name %s", data, server->pool->db->name);
 +
 +				if (!server->pool->parent_pool) {
@@ -193,6 +233,9 @@ index 4a4bbb7..7632738 100644
 +				server->pool->parent_pool->global_writer = server->pool;
 +				// new writer has been found, so indicate that we need to refresh the topology.
 +				server->pool->refresh_topology = true;
++				if (server->pool->db->recovery_query) {
++					routing_traffic_to_target_complete =  true;
++				}
 +			} else {
 +				log_debug("handle_server_work: connected to reader (pg_is_in_recovery is '%s'). db_name: %s, Must keep polling until next server.", data, server->pool->db->name);
 +			}
@@ -200,9 +243,9 @@ index 4a4bbb7..7632738 100644
 +			free(data);
 +		}
  		break;
-	}
-	server->idle_tx = idle_tx;
-@@ -632,7 +761,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 	}
+ 	server->idle_tx = idle_tx;
+@@ -632,7 +805,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -211,7 +254,7 @@ index 4a4bbb7..7632738 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +769,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +813,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -231,7 +274,7 @@ index 4a4bbb7..7632738 100644
  	return true;
  }
  
-@@ -754,6 +896,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +940,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -239,7 +282,7 @@ index 4a4bbb7..7632738 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +911,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +955,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -259,7 +302,7 @@ index 4a4bbb7..7632738 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +963,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1007,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..8390672 100644
+index c6e5efe..b2611e4 100644
 --- a/src/server.c
 +++ b/src/server.c
 @@ -27,6 +27,123 @@
@@ -126,21 +126,17 @@ index c6e5efe..8390672 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -122,6 +239,13 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -122,6 +239,9 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
 +	char *data = NULL;
-+	char *hostname = NULL;
-+	char *endpoint = NULL;
-+	char *role = NULL;
-+	char *port_str = NULL;
-+	char *status = NULL;
-+	int port_num = 0;
++	TopologyData *topology = NULL;
++	const char *topology_parser_msg;
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +257,28 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +253,28 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
  		case PqMsg_ReadyForQuery:
  		case PqMsg_ParameterStatus:
@@ -169,7 +165,7 @@ index c6e5efe..8390672 100644
  		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +292,115 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +288,53 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -177,106 +173,44 @@ index c6e5efe..8390672 100644
 +		if (fast_switchover && server->pool->db->topology_query && server->pool->initial_writer_endpoint) {
 +			data = query_data(pkt);
 +			if (data) {
-+				char *pointer_to_data = data;
-+				endpoint = strsep(&pointer_to_data, "\t");
-+				role = strsep(&pointer_to_data, "\t");
-+				port_str = strsep(&pointer_to_data, "\t");
-+				status = strsep(&pointer_to_data, "\t");
-+				/*
-+				 * In a Blue-Green deployment, the port and role are retrieved using the topology query.
-+				 * When PgBouncer is configured with the fast switchover feature enabled for Blue-Green deployment,
-+				 * it expects valid role and port values. If valid values are not found, PgBouncer will crash.
-+				 */
-+				if (server->pool->db->recovery_query) {
-+					if (role == NULL || port_str == NULL || status == NULL) {
-+						free(data);
-+						fatal("port, role or status cannot be null while using the Blue Green fast switchover, port: %s, role: %s, status: %s",
-+							port_str ? port_str : "NULL", role ? role : "NULL", status ? status : "NULL");
-+					}
-+					/*
-+					 * This check handles the scenario where the customer has configured the blue-green deployment fast switch feature
-+					 * but the endpoint is not part of a blue-green deployment.
-+					 * In such cases, we intentionally crash PgBouncer, as fast switchovers are not supported in other deployment topologies.
-+					 */
-+					if (strcmp(role, BLUE_GREEN_DEPLOYMENT_TARGET) != 0 && strcmp(role, BLUE_GREEN_DEPLOYMENT_SOURCE) != 0) {
-+						fatal("blue-green deployment fast switchover is only supported for roles '%s' or '%s'. The current role for your endpoint is: %s",
-+							BLUE_GREEN_DEPLOYMENT_TARGET, BLUE_GREEN_DEPLOYMENT_SOURCE, role);
-+					}
-+					port_num = atoi(port_str);
-+					if (port_num <= 0) {
-+						free(data);
-+						fatal("Invalid port number: %s", port_str);
-+					}
-+					/*
-+					 * This check handles the case where the customer has configured the blue-green deployment fast switch feature
-+					 * but is using the green endpoint.
-+					 * In this scenario, fast switchovers are not supported. Therefore, we update the customer with the appropriate message.
-+					 */
-+					if ((strcmp(role, BLUE_GREEN_DEPLOYMENT_TARGET) == 0) && (strcmp(server->pool->db->host, endpoint) == 0) && (strcmp(status, AVAILABLE) == 0)) {
-+						free(data);
-+						fatal("for blue green deployment green end point can not be configured to acheive fast switchover feature. Confgigured endpoint : %s", server->pool->db->host);
-+					}
-+				} else {
-+					/*
-+					 * This case handles situations where the customer has not configured the recovery query
-+					 * in a blue-green deployment setup.
-+					 */
-+					if (role && (strcmp(role, BLUE_GREEN_DEPLOYMENT_TARGET) == 0 || strcmp(role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0)) {
-+						fatal("recovery query is mandatory for the blue-green deployment fast switchover feature, but it is currently missing.");
-+					}
-+					port_num = server->pool->db->port;
-+				}
-+				log_debug("got initial data, endpoint: %s, role: %s, port: %d, status: %s", endpoint ? endpoint : "NULL",
-+					role ? role : "NULL", port_num, status ? status : "NULL");
-+			}
-+
-+			/* Make a copy of endpoint for hostname */
-+			hostname = strdup(endpoint);
-+			if (hostname == NULL) {
-+				free(data);
-+				fatal("strdup: no mem for hostname");
-+			}
-+			if (fast_switchover && server->pool->db->recovery_query) {
-+				/*
-+				 * Blue-Green Deployment Fast Switchover:
-+				 * Open connections only to the specified endpoint and its green counterpart; skip all other endpoints.
-+				 * Connection Pool Handling:
-+				 * - For writer endpoints (e.g., used with PgBouncer), ensure a connection is established to the corresponding writer on the green cluster.
-+				 * - For reader endpoints, establish a connection to the equivalent reader on the green cluster.
-+				 * - Apply the same logic for custom-defined endpoints.
-+				 */
-+				bool should_continue = setup_connection_pool_based_on_endpoint_type(server->pool->db->host, hostname);
-+				if (!should_continue) {
++				/* Parse topology data from a query result. */
++				topology_parser_msg = parse_topology_data(server, data, &topology);
++				if (topology_parser_msg) {
 +					free(data);
-+					free(hostname);
-+					sbuf_prepare_skip(sbuf, pkt->len);
-+					return true;
++					fatal("failed while parsing the topology data. Error msg : %s", topology_parser_msg);
 +				}
-+			}
 +
-+			if (!strtok(endpoint, ".")) {
-+				free(data);
-+				free(hostname);
-+				fatal("could not parse hostname from: %s", endpoint);
-+			} else {
-+				PgPool *new_pool = new_pool_from_db(server->pool->db, endpoint, hostname, port_num);
-+				if (new_pool) {
-+					new_pool->parent_pool = server->pool;
-+					new_pool->parent_pool->global_writer = server->pool;
-+					new_pool->db->topology_query = strdup(server->pool->db->topology_query);
-+					if (server->pool->db->recovery_query) {
-+						new_pool->db->recovery_query = strdup(server->pool->db->recovery_query);
-+						if (strcmp(role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0) {
-+							new_pool->db->is_source_db = true;
-+						}
++				if (server->pool->db->recovery_query) {
++					/*
++					 * Blue-Green Deployment Fast Switchover:
++					 * Open connections only to the specified endpoint and its green counterpart; skip all other endpoints.
++					 * Connection Pool Handling:
++					 * - For writer endpoints (e.g., used with PgBouncer), ensure a connection is established to the corresponding writer on the green cluster.
++					 * - For reader endpoints, establish a connection to the equivalent reader on the green cluster.
++					 * - Apply the same logic for custom-defined endpoints.
++					 */
++					bool should_continue = setup_connection_pool_based_on_endpoint_type(server->pool->db->host, &topology->endpoint);
++					if (!should_continue) {
++						free(data);
++						cleanup_topology(topology);
++						sbuf_prepare_skip(sbuf, pkt->len);
++						return true;
 +					}
-+					launch_new_connection(new_pool, true);
-+					server->pool->num_nodes++;
 +				}
-+			}
 +
-+			free(data);
-+			free(hostname);
++				/* Set up a new connection pool based on topology data. */
++				if (setup_new_pool(server, topology) == NULL) {
++					// Handle setup failure if needed
++					log_debug("Failed to initialize new connection pool for host '%s'. Possible issue with memory allocation, hostname parsing, or connection launch.",
++						topology->endpoint);
++					cleanup_topology(topology);
++					free(data);
++					fatal("Failed to set up connection pool. Aborting to prevent inconsistent topology state.");
++
++				}
++				cleanup_topology(topology);
++				free(data);
++			}
 +		}
 +
 +		sbuf_prepare_skip(sbuf, pkt->len);
@@ -285,7 +219,7 @@ index c6e5efe..8390672 100644
  	case PqMsg_ErrorResponse:
  		/*
  		 * If we cannot log into the server, then we drop all clients
-@@ -201,7 +450,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -201,7 +384,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -297,7 +231,7 @@ index c6e5efe..8390672 100644
 +				disconnect_server(server, false, "exec_on_connect query failed");
 +			break;
 +		} else if (fast_switchover && source_instance_down_before_switchover && server->pool->db->recovery_query) {
-+			if (server->pool->db->is_source_db) {
++			if (server->pool->db->blue_green_deployment_db_type == DEFAULT) {
 +				/*
 +				 * This scenario occurs when the source instance was down before the switchover and has now become available.
 +				 * During the handle server work, we monitor the metadata status. If the metadata entry shows AVAILABLE,
@@ -313,7 +247,7 @@ index c6e5efe..8390672 100644
 +			}
 +			source_instance_down_before_switchover = false;
 +		} else if (fast_switchover && server->pool->db->recovery_query && routing_traffic_to_target_complete) {
-+			if (server->pool->db->is_source_db) {
++			if (server->pool->db->blue_green_deployment_db_type == DEFAULT) {
 +				/*
 +				 * After the switchover is completed, we set 'routing_traffic_to_target_complete' to true in 'handle_server_work'.
 +				 * Once DNS resolution is complete for the target instance, the new DNS becomes available for queries.
@@ -346,7 +280,32 @@ index c6e5efe..8390672 100644
  
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -363,6 +665,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -352,6 +588,24 @@ int user_client_max_connections(PgGlobalUser *user)
+ 		return user->max_user_client_connections;
+ }
+ 
++/*
++ * Returns true if global writer is lost and need to update the global writer to accept writes.
++ *
++ * data: result from one of the three queries:
++ *   In case of Multi_AZ Cluster - SELECT pg_is_in_recovery(); -> "f" or "t"
++ *   In case of Blue Green Deployment of Instance - SELECT status FROM rds_tools.show_topology('pgbouncer');
++ *   In case of Blue Green Deployment of Cluster - SELECT status FROM get_blue_green_fast_switchover_metadata(\'pgbouncer\');
++ * db_type: the database type (e.g., DEFAULT) of the current pool
++ */
++
++static bool should_update_global_writer(const char *data, enum BlueGreenDeploymentDBType db_type) {
++	return	(strcmp(data, "f") == 0) ||
++			(strcmp(data, SWITCHOVER_IN_POST_PROCESSING) == 0) ||
++			(strcmp(data, SWITCHOVER_COMPLETED) == 0) ||
++			((strcmp(data, AVAILABLE) == 0) && (db_type == DEFAULT));
++}
++
++
+ /* process packets on logged in connection */
+ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ {
+@@ -363,6 +617,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
  	struct List *item, *tmp;
  	bool ignore_packet = false;
@@ -355,7 +314,7 @@ index c6e5efe..8390672 100644
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +678,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +630,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case PqMsg_ReadyForQuery:
@@ -371,7 +330,7 @@ index c6e5efe..8390672 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +774,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -461,6 +726,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		break;
  
  	case PqMsg_CommandComplete:
@@ -394,7 +353,7 @@ index c6e5efe..8390672 100644
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
  			slog_debug(server, "COPY finished");
-@@ -545,6 +874,53 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -545,6 +826,61 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case PqMsg_CopyData:
  	case PqMsg_DataRow:
@@ -410,8 +369,11 @@ index c6e5efe..8390672 100644
 +			 * Once the switchover begins, the recovery query will run on the target instance to retrieve the switchover status from the metadata table.
 +			 * When the status changes to either SWITCHOVER_IN_POST_PROCESSING or SWITCHOVER_COMPLETED,
 +			 * it indicates that the target instance is ready for accepting the writes, and we can safely update the global writer to point to the target instance.
++			 *
++			 * If the recovery query ran on a DEFAULT database type, and the topology data shows the Blue-Green deployment is in an AVAILABLE state,
++			 * that means the global writer was lost because the green (target) instance went down. So reset the global writer to the default database pool (server->pool)
 +			 */
-+			if (strcmp(data, "f") == 0 || ((strcmp(data, SWITCHOVER_IN_POST_PROCESSING) == 0) || (strcmp(data, SWITCHOVER_COMPLETED) == 0))) {
++			if (should_update_global_writer(data, server->pool->db->blue_green_deployment_db_type)) {
 +				log_debug("handle_server_work: connected to writer (pg_is_in_recovery is '%s'): db_name %s", data, server->pool->db->name);
 +
 +				if (!server->pool->parent_pool) {
@@ -420,7 +382,12 @@ index c6e5efe..8390672 100644
 +				server->pool->parent_pool->global_writer = server->pool;
 +				// new writer has been found, so indicate that we need to refresh the topology.
 +				server->pool->refresh_topology = true;
-+				if (server->pool->db->recovery_query) {
++				if (server->pool->db->recovery_query && server->pool->db->blue_green_deployment_db_type == BLUE_GREEN_TARGET) {
++					/*
++					 * At this point, we've run the recovery query on the green (target) instance.
++					 * The metadata table shows 'SWITCHOVER_IN_POST_PROCESSING', which meanss
++					 * green instance is now ready to accept write operations.
++					 */
 +					routing_traffic_to_target_complete =  true;
 +				}
 +			} else if (strcmp(data, AVAILABLE) == 0) {
@@ -448,7 +415,7 @@ index c6e5efe..8390672 100644
  		break;
  	}
  	server->idle_tx = idle_tx;
-@@ -632,7 +1008,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -632,7 +968,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -457,7 +424,7 @@ index c6e5efe..8390672 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +1016,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +976,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -477,7 +444,7 @@ index c6e5efe..8390672 100644
  	return true;
  }
  
-@@ -754,6 +1143,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +1103,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -485,7 +452,7 @@ index c6e5efe..8390672 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +1158,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +1118,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -505,7 +472,7 @@ index c6e5efe..8390672 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +1210,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1170,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);
@@ -516,3 +483,267 @@ index c6e5efe..8390672 100644
  		disconnect_server(server, false, "connect failed");
  		break;
  	case SBUF_EV_CONNECT_OK:
+@@ -893,3 +1257,262 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+ 		takeover_login_failed();
+ 	return res;
+ }
++
++/**
++ * @brief Parse and validate topology data from a query result.
++ *
++ * This function parses the raw tab-separated data from a topology query into a
++ * dynamically allocated TopologyData structure. It performs validation checks
++ * based on the deployment configuration, particularly for Blue-Green setups.
++ *
++ * @param server        The PgSocket associated with the query context.
++ * @param data          The raw string data returned from the topology query.
++ * @param topology_out  Output parameter; on success, points to the populated TopologyData structure.
++ *
++ * @return NULL on success, or a static error message string if parsing or validation fails.
++ *
++ * @note This function performs the following steps:
++ *       1. Allocates memory for the TopologyData structure.
++ *       2. Parses the input string into endpoint, role, port, and status fields.
++ *       3. Validates the parsed data based on the server's deployment configuration.
++ *       4. Converts the port string to an integer.
++ *       5. Enforces rules specific to Blue-Green deployments.
++ *
++ * @attention The caller is responsible for:
++ *            - Logging or handling the returned error message, if any.
++ *            - Freeing the allocated TopologyData structure on success.
++ *
++ * @warning This function no longer calls fatal() internally. Instead, it returns
++ *          descriptive error strings on failure, allowing the caller to decide how
++ *          to handle errors.
++ *
++ * @see TopologyData
++ * @see cleanup_topology()
++ * @see BLUE_GREEN_DEPLOYMENT_TARGET
++ * @see BLUE_GREEN_DEPLOYMENT_SOURCE
++ */
++const char* parse_topology_data(PgSocket *server, char *data, TopologyData **topology_out) {
++    TopologyData *topology = malloc(sizeof(TopologyData));
++    if (!topology) {
++		return "malloc failed: no memory for topology data";
++	}
++
++	memset(topology, 0, sizeof(TopologyData)); // Initialize to zero
++
++	// Make a copy of data since strsep modifies it
++	char *data_copy = strdup(data);
++	if (!data_copy) {
++		cleanup_topology(topology);
++		return "strdup failed: no memory for data copy";
++
++	}
++
++	char *pointer_to_data = data_copy;
++	char *token;
++	char *port_str = NULL;
++
++	// Parse endpoint
++	token = strsep(&pointer_to_data, "\t");
++	topology->endpoint = token ? strdup(token) : NULL;
++	if (!topology->endpoint) {
++		cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++		return "strdup failed: no memory for topology->endpoint";
++	}
++
++	// Parse role
++	token = strsep(&pointer_to_data, "\t");
++	if (token) {
++		topology->role = strdup(token);
++		if (!topology->role) {
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "strdup failed: no memory for topology->role";
++		}
++	}
++
++	// Parse port
++	token = strsep(&pointer_to_data, "\t");
++	if (token) {
++		port_str = strdup(token);
++		if (!port_str) {
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "strdup failed: no memory for port_str";
++		}
++	}
++
++	// Parse status
++	token = strsep(&pointer_to_data, "\t");
++	if (token) {
++		topology->status = strdup(token);
++		if (!topology->status) {
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "strdup failed: no memory for topology->status";
++		}
++	}
++
++	if (server->pool->db->recovery_query) {
++		/*
++		 * In a Blue-Green deployment, the port and role are retrieved using the topology query.
++		 * When PgBouncer is configured with the fast switchover feature enabled for Blue-Green deployment,
++		 * it expects valid role and port values. If valid values are not found, PgBouncer will crash.
++		 */
++		if (topology->role == NULL || port_str == NULL || topology->status == NULL) {
++			log_debug("port, role and status for Blue Green fast switchover, port: %s, role: %s, status: %s",
++				port_str ? port_str : "NULL", topology->role ? topology->role : "NULL", topology->status ? topology->status : "NULL");
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "port, role or status cannot be null while using the Blue Green fast switchover";
++		}
++
++		/*
++		 * This check handles the scenario where the customer has configured the blue-green deployment fast switch feature
++		 * but the endpoint is not part of a blue-green deployment.
++		 * In such cases, we intentionally crash PgBouncer, as fast switchovers are not supported in other deployment topologies.
++		 */
++		if (strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_TARGET) != 0 &&
++			strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_SOURCE) != 0) {
++			log_debug("The current role for your endpoint is: %s", topology->role);
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "blue-green deployment fast switchover is only supported for BLUE_GREEN_DEPLOYMENT_SOURCE and BLUE_GREEN_DEPLOYMENT_TARGET roles";
++		}
++
++		topology->port_num = atoi(port_str);
++		if (topology->port_num <= 0) {
++			log_debug("port number: %s", port_str);
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "Invalid port number in topology metadata table";
++		}
++
++		/*
++		 * This check handles the case where the customer has configured the blue-green deployment fast switch feature
++		 * but is using the green endpoint.
++		 * In this scenario, fast switchovers are not supported. Therefore, we update the customer with the appropriate message.
++		 */
++		if ((strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_TARGET) == 0) &&
++			(strcmp(server->pool->db->host, topology->endpoint) == 0) &&
++			(strcmp(topology->status, AVAILABLE) == 0)) {
++			log_debug("Configured endpoint : %s", server->pool->db->host);
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "for blue green deployment target(green) end point cannot be configured to achieve fast switchover feature.";
++		}
++    } else {
++		/*
++		 * This case handles situations where the customer has not configured the recovery query
++		 * in a blue-green deployment setup.
++		 */
++		if (topology->role && (strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_TARGET) == 0 ||
++			strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0)) {
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "recovery query is mandatory for the blue-green deployment fast switchover feature, but it is currently missing.";
++		}
++		topology->port_num = server->pool->db->port;
++	}
++
++	log_debug("got initial data, endpoint: %s, role: %s, port: %d, status: %s",
++		topology->endpoint ? topology->endpoint : "NULL",
++		topology->role ? topology->role : "NULL",
++		topology->port_num,
++		topology->status ? topology->status : "NULL");
++
++	free(port_str);
++	free(data_copy);
++	*topology_out = topology;
++	return NULL;
++}
++
++/**
++ * @brief Set up a new connection pool based on topology data.
++ *
++ * This function creates and configures a new PgPool instance using the provided topology data.
++ *
++ * @param server The server socket associated with the current connection.
++ * @param topology A pointer to the TopologyData structure containing parsed topology information.
++ * @param hostname The hostname for the new pool, derived from the topology endpoint.
++ *
++ * @return A pointer to the newly created PgPool if successful, or NULL if an error occurred.
++ *
++ * @note This function performs the following steps:
++ *       1. Validates and parses the hostname from the topology endpoint.
++ *       2. Creates a new pool using new_pool_from_db().
++ *       3. Sets up parent pool relationships and global writer.
++ *       4. Copies topology and recovery queries from the original pool.
++ *       5. Sets the Blue-Green deployment type based on the topology role.
++ *       6. Launches a new connection for the pool.
++ *       7. Increments the node count in the server's pool.
++ *
++ * @warning This function calls fatal() if it cannot parse the hostname, which may terminate the program.
++ *
++ * @warning The function assumes that the input parameters are valid and have been properly allocated.
++ *          It's the caller's responsibility to free the TopologyData and hostname after this function returns.
++ *
++ * @see new_pool_from_db()
++ * @see launch_new_connection()
++ */
++PgPool* setup_new_pool(PgSocket *server, TopologyData *topology) {
++	/* Make a copy of endpoint for hostname */
++	char* hostname = strdup(topology->endpoint);
++	if (hostname == NULL) {
++		log_debug("strdup: no mem for hostname");
++		return NULL;
++	}
++	if (!strtok(topology->endpoint, ".")) {
++		log_debug("could not parse hostname present in topology, hostname to parse: %s", topology->endpoint);
++		free(hostname);
++		return NULL;
++	}
++    PgPool *new_pool = new_pool_from_db(server->pool->db, topology->endpoint, hostname, topology->port_num);
++    if (!new_pool) {
++		free(hostname);
++		return NULL;
++    }
++
++    new_pool->parent_pool = server->pool;
++    new_pool->parent_pool->global_writer = server->pool;
++    new_pool->db->topology_query = strdup(server->pool->db->topology_query);
++	if (new_pool->db->topology_query == NULL) {
++		log_debug("strdup: no mem for topology_query");
++		return NULL;
++	}
++
++    if (server->pool->db->recovery_query) {
++		new_pool->db->recovery_query = strdup(server->pool->db->recovery_query);
++		if (new_pool->db->recovery_query == NULL) {
++			log_debug("strdup: no mem for recovery_query");
++			return NULL;
++		}
++		if (strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0) {
++			new_pool->db->blue_green_deployment_db_type = BLUE_GREEN_SOURCE;
++		} else if (strcmp(topology->role, BLUE_GREEN_DEPLOYMENT_TARGET) == 0) {
++			new_pool->db->blue_green_deployment_db_type = BLUE_GREEN_TARGET;
++		}
++    }
++
++    launch_new_connection(new_pool, true);
++    server->pool->num_nodes++;
++
++	free(hostname);
++	return new_pool;
++}
++
++void cleanup_parsing_data_and_exit(TopologyData *topology, char *data_copy, char *port_str) {
++	cleanup_topology(topology);
++	if (data_copy) {
++		free(data_copy);
++	}
++	if (port_str) {
++		free(port_str);
++	}
++}
++
++void cleanup_topology(TopologyData *topology) {
++	if (topology) {
++		if (topology->endpoint) {
++			free(topology->endpoint);
++		}
++		if (topology->role) {
++			free(topology->role);
++		}
++		if (topology->status) {
++			free(topology->status);
++		}
++		free(topology);
++	}
++}
+\ No newline at end of file

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..116e344 100644
+index c6e5efe..8390672 100644
 --- a/src/server.c
 +++ b/src/server.c
 @@ -27,6 +27,123 @@
@@ -126,7 +126,7 @@ index c6e5efe..116e344 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -122,6 +239,12 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -122,6 +239,13 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
@@ -135,11 +135,12 @@ index c6e5efe..116e344 100644
 +	char *endpoint = NULL;
 +	char *role = NULL;
 +	char *port_str = NULL;
++	char *status = NULL;
 +	int port_num = 0;
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +256,28 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +257,28 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
  		case PqMsg_ReadyForQuery:
  		case PqMsg_ParameterStatus:
@@ -168,7 +169,7 @@ index c6e5efe..116e344 100644
  		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +291,88 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +292,115 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
@@ -178,28 +179,55 @@ index c6e5efe..116e344 100644
 +			if (data) {
 +				char *pointer_to_data = data;
 +				endpoint = strsep(&pointer_to_data, "\t");
++				role = strsep(&pointer_to_data, "\t");
++				port_str = strsep(&pointer_to_data, "\t");
++				status = strsep(&pointer_to_data, "\t");
 +				/*
 +				 * In a Blue-Green deployment, the port and role are retrieved using the topology query.
 +				 * When PgBouncer is configured with the fast switchover feature enabled for Blue-Green deployment,
 +				 * it expects valid role and port values. If valid values are not found, PgBouncer will crash.
 +				 */
 +				if (server->pool->db->recovery_query) {
-+					role = strsep(&pointer_to_data, "\t");
-+					port_str = strsep(&pointer_to_data, "\t");
-+					if (role == NULL || port_str == NULL) {
++					if (role == NULL || port_str == NULL || status == NULL) {
 +						free(data);
-+						fatal("port or role cannot be null while using the Blue Green fast switchover, port: %s, role: %s",
-+							port_str ? port_str : "NULL", role ? role : "NULL");
++						fatal("port, role or status cannot be null while using the Blue Green fast switchover, port: %s, role: %s, status: %s",
++							port_str ? port_str : "NULL", role ? role : "NULL", status ? status : "NULL");
++					}
++					/*
++					 * This check handles the scenario where the customer has configured the blue-green deployment fast switch feature
++					 * but the endpoint is not part of a blue-green deployment.
++					 * In such cases, we intentionally crash PgBouncer, as fast switchovers are not supported in other deployment topologies.
++					 */
++					if (strcmp(role, BLUE_GREEN_DEPLOYMENT_TARGET) != 0 && strcmp(role, BLUE_GREEN_DEPLOYMENT_SOURCE) != 0) {
++						fatal("blue-green deployment fast switchover is only supported for roles '%s' or '%s'. The current role for your endpoint is: %s",
++							BLUE_GREEN_DEPLOYMENT_TARGET, BLUE_GREEN_DEPLOYMENT_SOURCE, role);
 +					}
 +					port_num = atoi(port_str);
 +					if (port_num <= 0) {
 +						free(data);
 +						fatal("Invalid port number: %s", port_str);
 +					}
++					/*
++					 * This check handles the case where the customer has configured the blue-green deployment fast switch feature
++					 * but is using the green endpoint.
++					 * In this scenario, fast switchovers are not supported. Therefore, we update the customer with the appropriate message.
++					 */
++					if ((strcmp(role, BLUE_GREEN_DEPLOYMENT_TARGET) == 0) && (strcmp(server->pool->db->host, endpoint) == 0) && (strcmp(status, AVAILABLE) == 0)) {
++						free(data);
++						fatal("for blue green deployment green end point can not be configured to acheive fast switchover feature. Confgigured endpoint : %s", server->pool->db->host);
++					}
 +				} else {
++					/*
++					 * This case handles situations where the customer has not configured the recovery query
++					 * in a blue-green deployment setup.
++					 */
++					if (role && (strcmp(role, BLUE_GREEN_DEPLOYMENT_TARGET) == 0 || strcmp(role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0)) {
++						fatal("recovery query is mandatory for the blue-green deployment fast switchover feature, but it is currently missing.");
++					}
 +					port_num = server->pool->db->port;
 +				}
-+				log_debug("got initial data, endpoint: %s, role: %s, port: %d", endpoint ? endpoint : "NULL", role ? role : "NULL", port_num);
++				log_debug("got initial data, endpoint: %s, role: %s, port: %d, status: %s", endpoint ? endpoint : "NULL",
++					role ? role : "NULL", port_num, status ? status : "NULL");
 +			}
 +
 +			/* Make a copy of endpoint for hostname */
@@ -257,7 +285,7 @@ index c6e5efe..116e344 100644
  	case PqMsg_ErrorResponse:
  		/*
  		 * If we cannot log into the server, then we drop all clients
-@@ -201,7 +422,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -201,7 +450,60 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -318,7 +346,7 @@ index c6e5efe..116e344 100644
  
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -363,6 +637,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -363,6 +665,8 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
  	struct List *item, *tmp;
  	bool ignore_packet = false;
@@ -327,7 +355,7 @@ index c6e5efe..116e344 100644
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +650,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +678,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case PqMsg_ReadyForQuery:
@@ -343,7 +371,7 @@ index c6e5efe..116e344 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +746,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -461,6 +774,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		break;
  
  	case PqMsg_CommandComplete:
@@ -366,7 +394,7 @@ index c6e5efe..116e344 100644
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
  			slog_debug(server, "COPY finished");
-@@ -545,6 +846,53 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -545,6 +874,53 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case PqMsg_CopyData:
  	case PqMsg_DataRow:
@@ -420,7 +448,7 @@ index c6e5efe..116e344 100644
  		break;
  	}
  	server->idle_tx = idle_tx;
-@@ -632,7 +980,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -632,7 +1008,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -429,7 +457,7 @@ index c6e5efe..116e344 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +988,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +1016,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -449,7 +477,7 @@ index c6e5efe..116e344 100644
  	return true;
  }
  
-@@ -754,6 +1115,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +1143,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -457,7 +485,7 @@ index c6e5efe..116e344 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +1130,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +1158,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -477,7 +505,7 @@ index c6e5efe..116e344 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +1182,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1210,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..d2a6780 100644
+index c6e5efe..eb8ded7 100644
 --- a/src/server.c
 +++ b/src/server.c
 @@ -27,6 +27,125 @@
@@ -654,7 +654,7 @@ index c6e5efe..d2a6780 100644
  		disconnect_server(server, false, "connect failed");
  		break;
  	case SBUF_EV_CONNECT_OK:
-@@ -893,3 +1428,267 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -893,3 +1428,279 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		takeover_login_failed();
  	return res;
  }
@@ -773,6 +773,18 @@ index c6e5efe..d2a6780 100644
 +			log_debug("The current role for your endpoint is: %s", topology->role);
 +			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
 +			return "blue-green deployment fast switchover is only supported for BLUE_GREEN_DEPLOYMENT_SOURCE and BLUE_GREEN_DEPLOYMENT_TARGET roles";
++		}
++
++		/*
++		 * In a Blue-Green deployment for a cluster, fast switchover only works with cluster endpoints
++		 * (reader, writer, or custom).
++		 * Make sure the user has configured cluster endpoints, not instance endpoints of the cluster.
++		 */
++		if (is_cluster_endpoint(topology->endpoint) && !is_cluster_endpoint(server->pool->db->host)) {
++			cleanup_parsing_data_and_exit(topology, data_copy, port_str);
++			return "For a cluster, fast switchover during blue-green deployment only supports cluster endpoints "
++				"(reader, writer, or custom). It looks like an instance endpoint is configured instead. "
++				"Please update the configuration to use a valid cluster endpoint.";
 +		}
 +
 +		topology->port_num = atoi(port_str);

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,46 +1,122 @@
 diff --git a/src/server.c b/src/server.c
-index c6e5efe..c46ef7b 100644
+index c6e5efe..ef0cdb3 100644
 --- a/src/server.c
 +++ b/src/server.c
-@@ -27,6 +27,46 @@
+@@ -27,6 +27,122 @@
  
  #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
  
 +bool routing_traffic_to_target_complete = false;
 +
-+/*
-+* Returns the query data from the server. This must be freed.
-+*/
++/**
++ * Extracts and processes query result data from a packet into a tab-separated string.
++ *
++ * This function performs the following steps:
++ * 1. Reads the number of columns from the packet header
++ * 2. Calculates total required buffer length in first pass
++ * 3. Allocates memory for output string
++ * 4. Copies column data with tab separators in second pass
++ *
++ * The returned string format is: col1\tcol2\tcol3...\tcolN\0
++ *
++ * @param pkt       Pointer to PktHdr structure containing raw packet data
++ *                  Must contain valid column count and column data
++ *
++ * @return          On success: Pointer to newly allocated string containing tab-separated column data
++ *                  On failure: NULL (with error logged)
++ *                  Caller must free the returned string
++ *
++ * @note           Function will return NULL and log error if:
++ *                 - Cannot read column count
++ *                 - Zero columns in packet
++ *                 - Cannot read column lengths or data
++ *                 - Memory allocation fails
++ *                 - Final position doesn't match calculated length
++ *
++ * @warning        The returned string must be freed by the caller to avoid memory leaks
++ */
++
 +static char *query_data(PktHdr *pkt)
 +{
 +	uint16_t columns;
 +	uint32_t length;
 +	const char *data;
-+	char *output;
++	char *output = NULL;
++	size_t total_length = 0;
++	size_t pos = 0;
++	int i;
++	struct MBuf tmp_buf;
++	const uint8_t *dummy;
 +
-+	if (!mbuf_get_uint16be(&pkt->data, &columns))
-+	{
++	/* Get number of columns */
++	if (!mbuf_get_uint16be(&pkt->data, &columns)) {
 +		log_error("could not get packet column count");
 +		return NULL;
 +	}
-+	if (!mbuf_get_uint32be(&pkt->data, &length))
-+	{
-+		log_error("could not get packet length");
-+		return NULL;
-+	}
-+	if (!mbuf_get_chars(&pkt->data, length, &data))
-+	{
-+		log_error("could not get packet data");
++
++	if (columns == 0) {
++		log_error("zero columns in packet");
 +		return NULL;
 +	}
 +
-+	output = strndup(data, length);
++	/* First pass: calculate total length needed */
++	mbuf_copy(&pkt->data, &tmp_buf);  /* Create a copy of the buffer */
++	for (i = 0; i < columns; i++) {
++		if (!mbuf_get_uint32be(&tmp_buf, &length)) {
++			log_error("could not get column %d length", i);
++			return NULL;
++		}
++
++		total_length += length;
++
++		if (!mbuf_get_bytes(&tmp_buf, length, &dummy)) {
++			log_error("could not skip column %d data", i);
++			return NULL;
++		}
++	}
++
++	/* Account for tabs between columns (columns - 1) and 1 null terminator */
++	total_length += (columns - 1) + 1;
++
++	/* Allocate buffer */
++	output = malloc(total_length);
 +	if (output == NULL) {
-+		log_error("strdup: no mem in query_data");
++		log_error("malloc failed: no memory in query_data");
 +		return NULL;
 +	}
 +
-+	log_debug("data from DataRow: %s, length: %d, strlen: %lu", output, length, strlen(output));
++	/* Second pass: actually fetch the data */
++	for (i = 0; i < columns; i++) {
++		if (!mbuf_get_uint32be(&pkt->data, &length)) {
++			log_error("could not get column %d length (second pass)", i);
++			free(output);
++			return NULL;
++		}
++
++		if (!mbuf_get_chars(&pkt->data, length, &data)) {
++			log_error("could not get column %d data (second pass)", i);
++			free(output);
++			return NULL;
++		}
++
++		/* Copy column data */
++		memcpy(output + pos, data, length);
++		pos += length;
++
++		/* Add separator (tab or null terminator) */
++		if (i < columns - 1) {
++			output[pos++] = '\t';
++		} else {
++			output[pos++] = '\0';  /* final null terminator */
++		}
++	}
++
++	if (pos != total_length) {
++		free(output);
++		fatal("final position (%zu) does not match calculated total_length (%zu)", pos, total_length);
++	}
++
++	log_debug("Extracted data: [%s], total_length: %zu, final_pos: %zu", output, total_length, pos);
 +
 +	return output;
 +}
@@ -49,16 +125,20 @@ index c6e5efe..c46ef7b 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -122,6 +162,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -122,6 +238,12 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
 +	char *data = NULL;
 +	char *hostname = NULL;
++	char *endpoint = NULL;
++	char *role = NULL;
++	char *port_str = NULL;
++	int port_num = 0;
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -133,12 +175,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -133,12 +255,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
  		case PqMsg_ReadyForQuery:
  		case PqMsg_ParameterStatus:
@@ -75,32 +155,62 @@ index c6e5efe..c46ef7b 100644
  		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -152,6 +198,41 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +278,71 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
 +	case PqMsg_DataRow:
 +		if (fast_switchover && server->pool->db->topology_query && server->pool->initial_writer_endpoint) {
 +			data = query_data(pkt);
-+			log_debug("got initial data: %s", data);
-+
-+			hostname = strdup(data);
-+			if (hostname == NULL) {
-+				log_error("strdup: no mem for hostname");
-+				free(data);
-+				return NULL;
++			if (data) {
++				char *pointer_to_data = data;
++				endpoint = strsep(&pointer_to_data, "\t");
++				/*
++				 * In a Blue-Green deployment, the port and role are retrieved using the topology query.
++				 * When PgBouncer is configured with the fast switchover feature enabled for Blue-Green deployment,
++				 * it expects valid role and port values. If valid values are not found, PgBouncer will crash.
++				 */
++				if (server->pool->db->recovery_query) {
++					role = strsep(&pointer_to_data, "\t");
++					port_str = strsep(&pointer_to_data, "\t");
++					if (role == NULL || port_str == NULL) {
++						free(data);
++						fatal("port or role cannot be null while using the Blue Green fast switchover, port: %s, role: %s",
++							port_str ? port_str : "NULL", role ? role : "NULL");
++					}
++					port_num = atoi(port_str);
++					if (port_num <= 0) {
++						free(data);
++						fatal("Invalid port number: %s", port_str);
++					}
++				} else {
++					port_num = server->pool->db->port;
++				}
++				log_debug("got initial data, endpoint: %s, role: %s, port: %d", endpoint ? endpoint : "NULL", role ? role : "NULL", port_num);
 +			}
 +
-+			if (!strtok(data, ".")) {
-+				log_error("could not parse hostname from: %s", data);
++			/* Make a copy of endpoint for hostname */
++			hostname = strdup(endpoint);
++			if (hostname == NULL) {
++				free(data);
++				fatal("strdup: no mem for hostname");
++			}
++
++			if (!strtok(endpoint, ".")) {
++				free(data);
++				free(hostname);
++				fatal("could not parse hostname from: %s", endpoint);
 +			} else {
-+				PgPool *new_pool = new_pool_from_db(server->pool->db, data, hostname);
++				PgPool *new_pool = new_pool_from_db(server->pool->db, endpoint, hostname, port_num);
 +				if (new_pool) {
 +					new_pool->parent_pool = server->pool;
 +					new_pool->parent_pool->global_writer = server->pool;
 +					new_pool->db->topology_query = strdup(server->pool->db->topology_query);
 +					if (server->pool->db->recovery_query) {
 +						new_pool->db->recovery_query = strdup(server->pool->db->recovery_query);
++						if (strcmp(role, BLUE_GREEN_DEPLOYMENT_SOURCE) == 0) {
++							new_pool->db->is_source_db = true;
++						}
 +					}
 +					launch_new_connection(new_pool, true);
 +					server->pool->num_nodes++;
@@ -117,7 +227,7 @@ index c6e5efe..c46ef7b 100644
  	case PqMsg_ErrorResponse:
  		/*
  		 * If we cannot log into the server, then we drop all clients
-@@ -201,7 +282,42 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -201,7 +392,42 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -160,7 +270,7 @@ index c6e5efe..c46ef7b 100644
  
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -363,6 +479,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -363,6 +589,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
  	struct List *item, *tmp;
  	bool ignore_packet = false;
@@ -168,7 +278,7 @@ index c6e5efe..c46ef7b 100644
  
  	Assert(!server->pool->db->admin);
  
-@@ -374,6 +491,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +601,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
  	case PqMsg_ReadyForQuery:
@@ -184,7 +294,7 @@ index c6e5efe..c46ef7b 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -461,6 +587,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -461,6 +697,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		break;
  
  	case PqMsg_CommandComplete:
@@ -207,7 +317,7 @@ index c6e5efe..c46ef7b 100644
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
  			slog_debug(server, "COPY finished");
-@@ -545,6 +687,37 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -545,6 +797,37 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case PqMsg_CopyData:
  	case PqMsg_DataRow:
@@ -245,7 +355,7 @@ index c6e5efe..c46ef7b 100644
  		break;
  	}
  	server->idle_tx = idle_tx;
-@@ -632,7 +805,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -632,7 +915,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -254,7 +364,7 @@ index c6e5efe..c46ef7b 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -640,6 +813,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -640,6 +923,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -274,7 +384,7 @@ index c6e5efe..c46ef7b 100644
  	return true;
  }
  
-@@ -754,6 +940,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +1050,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -282,7 +392,7 @@ index c6e5efe..c46ef7b 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -768,8 +955,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +1065,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -302,7 +412,7 @@ index c6e5efe..c46ef7b 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -810,6 +1007,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +1117,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);

--- a/src/util.c.diff
+++ b/src/util.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/util.c b/src/util.c
-index fad0172..d175376 100644
+index fad0172..af5c802 100644
 --- a/src/util.c
 +++ b/src/util.c
 @@ -32,6 +32,33 @@
@@ -45,8 +45,8 @@ index fad0172..d175376 100644
 +	return !pool->db->topology_query || !fast_switchover;
 +}
 +
-+bool setup_connection_pool_based_on_endpoint_type(char *hostName, char *endpoint) {
-+	if (!hostName || !endpoint)
++bool setup_connection_pool_based_on_endpoint_type(char *hostName, char **endpoint) {
++	if (!hostName || !*endpoint)
 +		return false;
 +	if (!is_cluster_endpoint(hostName))
 +		return true;
@@ -59,7 +59,7 @@ index fad0172..d175376 100644
 +		goto cleanup;
 +
 +	/* Get endpoint parts */
-+	if (!split_dbname_and_dnsname(endpoint, &endpoint_db, &endpoint_dns))
++	if (!split_dbname_and_dnsname(*endpoint, &endpoint_db, &endpoint_dns))
 +		goto cleanup;
 +
 +	/* Determine cluster types */
@@ -156,11 +156,11 @@ index fad0172..d175376 100644
 + * we will use the corresponding writer endpoint and insert the "-ro-" segment
 + * before establishing the connection in the pool.
 + */
-+bool append_ro_suffix_to_cluster_reader_endpoint(char* endpoint, size_t endpoint_size) {
-+	if (!endpoint || endpoint_size == 0 || endpoint_size > MAX_ENDPOINT_LENGTH)
++bool append_ro_suffix_to_cluster_reader_endpoint(char** endpoint, size_t endpoint_size) {
++	if (!*endpoint || endpoint_size == 0 || endpoint_size > MAX_ENDPOINT_LENGTH)
 +		return false;
 +
-+	const char* first_dot = strchr(endpoint, '.');
++	const char* first_dot = strchr(*endpoint, '.');
 +	if (!first_dot)
 +		return false;
 +
@@ -170,7 +170,7 @@ index fad0172..d175376 100644
 +		return false;
 +
 +	/* Pre-calculate all lengths */
-+	const size_t db_name_len = first_dot - endpoint;
++	const size_t db_name_len = first_dot - *endpoint;
 +	const size_t before_cluster_len = cluster_pos - dns_portion;
 +	const size_t cluster_prefix_len = strlen(CLUSTER_DASH_PREFIX);
 +	const size_t cluster_suffix_len = strlen(cluster_pos + cluster_prefix_len);
@@ -180,11 +180,11 @@ index fad0172..d175376 100644
 +	if (total_len > endpoint_size)
 +		return false;
 +
-+	char temp[MAX_ENDPOINT_LENGTH];
++	char temp[MAX_ENDPOINT_LENGTH] = {0};
 +	size_t pos = 0;
 +
 +	/* Build new string */
-+	memcpy(temp, endpoint, db_name_len);
++	memcpy(temp, *endpoint, db_name_len);
 +	pos += db_name_len;
 +	temp[pos++] = '.';
 +	memcpy(temp + pos, dns_portion, before_cluster_len);
@@ -195,8 +195,8 @@ index fad0172..d175376 100644
 +	pos += cluster_suffix_len;
 +	temp[pos] = '\0';
 +
-+	/* Copy back to endpoint */
-+	memcpy(endpoint, temp, total_len);
++	*endpoint = realloc(*endpoint, total_len);
++	memcpy(*endpoint, temp, total_len);
 +	return true;
 +}
 +

--- a/src/util.c.diff
+++ b/src/util.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/util.c b/src/util.c
-index fad0172..eaaadc0 100644
+index fad0172..d175376 100644
 --- a/src/util.c
 +++ b/src/util.c
 @@ -32,6 +32,33 @@
@@ -36,11 +36,179 @@ index fad0172..eaaadc0 100644
  int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstlen)
  {
  	const struct PgSocket *sock = ctx;
-@@ -532,3 +559,7 @@ bool check_reserved_database(const char *value)
+@@ -532,3 +559,175 @@ bool check_reserved_database(const char *value)
  	}
  	return true;
  }
 +
 +bool is_fast_switchover_disabled_for_pool(PgPool *pool) {
 +	return !pool->db->topology_query || !fast_switchover;
++}
++
++bool setup_connection_pool_based_on_endpoint_type(char *hostName, char *endpoint) {
++	if (!hostName || !endpoint)
++		return false;
++	if (!is_cluster_endpoint(hostName))
++		return true;
++	char *hostname_db = NULL, *hostname_dns = NULL;
++	char *endpoint_db = NULL, *endpoint_dns = NULL;
++	bool result = false;
++
++	/* Get hostname parts */
++	if (!split_dbname_and_dnsname(hostName, &hostname_db, &hostname_dns))
++		goto cleanup;
++
++	/* Get endpoint parts */
++	if (!split_dbname_and_dnsname(endpoint, &endpoint_db, &endpoint_dns))
++		goto cleanup;
++
++	/* Determine cluster types */
++	HostClusterEndPointType host_cluster_endpoint_type = HOST_CLUSTER_ENDPOINT_TYPE_WRITER;
++	if (strstr(hostname_dns, CLUSTER_RO))
++		host_cluster_endpoint_type = HOST_CLUSTER_ENDPOINT_TYPE_READER_ONLY;
++	else if (strstr(hostname_dns, CLUSTER_CUSTOM))
++		host_cluster_endpoint_type = HOST_CLUSTER_ENDPOINT_TYPE_CUSTOM;
++
++	/* Process based on cluster type */
++	switch (host_cluster_endpoint_type) {
++	case HOST_CLUSTER_ENDPOINT_TYPE_WRITER:
++		result = !strstr(endpoint_dns, CLUSTER_CUSTOM);
++		break;
++	case HOST_CLUSTER_ENDPOINT_TYPE_READER_ONLY:
++		if (strstr(endpoint_dns, CLUSTER_CUSTOM)) {
++			result = false;
++		} else {
++			result = append_ro_suffix_to_cluster_reader_endpoint(endpoint, MAX_ENDPOINT_LENGTH);
++		}
++		break;
++	case HOST_CLUSTER_ENDPOINT_TYPE_CUSTOM:
++		if (!strstr(endpoint_dns, CLUSTER_CUSTOM)) {
++			result = false;
++		} else {
++			char* endpoint_db_compare = strdup(endpoint_db);
++			if (endpoint_db_compare) {
++				char* last_green_pos = strstr(endpoint_db_compare, CLUSTER_GREEN_TAG);
++				if (last_green_pos) {
++					char* next_pos;
++					/* Find the last occurrence of CLUSTER_GREEN_TAG */
++					while ((next_pos = strstr(last_green_pos + 1, CLUSTER_GREEN_TAG)) != NULL) {
++						last_green_pos = next_pos;
++					}
++					/* Truncate the string */
++					*last_green_pos = '\0';
++				}
++				result = (strcmp(hostname_db, endpoint_db_compare) == 0);
++				free(endpoint_db_compare);
++			}
++		}
++		break;
++	}
++
++cleanup:
++	free(hostname_db);
++	free(hostname_dns);
++	free(endpoint_db);
++	free(endpoint_dns);
++	return result;
++}
++
++bool split_dbname_and_dnsname(char *endpoint, char **db_name, char **dns_name) {
++	if (!endpoint || !db_name || !dns_name)
++		return false;
++
++	const char *dot = strchr(endpoint, '.');
++	if (!dot)
++		return false;
++
++	size_t db_len = dot - endpoint;
++
++	/* Free existing memory */
++	if (*db_name) {
++		free(*db_name);
++		*db_name = NULL;
++	}
++	if (*dns_name) {
++		free(*dns_name);
++		*dns_name = NULL;
++	}
++	/* Allocate and copy db_name */
++	*db_name = malloc(db_len + 1);
++	if (!*db_name) return false;
++
++	memcpy(*db_name, endpoint, db_len);
++	(*db_name)[db_len] = '\0';
++
++	/* Allocate and copy dns_name */
++	*dns_name = strdup(dot + 1);
++	if (!*dns_name) {
++		free(*db_name);
++		*db_name = NULL;
++		return false;
++	}
++
++	return true;
++}
++
++/*
++ * The metadata table contains entries only for writer and custom endpoints.
++ * The reader endpoint differs from the writer endpoint by including the "-ro-" segment after "cluster".
++ * If the customer configures PgBouncer with a cluster reader endpoint,
++ * we will use the corresponding writer endpoint and insert the "-ro-" segment
++ * before establishing the connection in the pool.
++ */
++bool append_ro_suffix_to_cluster_reader_endpoint(char* endpoint, size_t endpoint_size) {
++	if (!endpoint || endpoint_size == 0 || endpoint_size > MAX_ENDPOINT_LENGTH)
++		return false;
++
++	const char* first_dot = strchr(endpoint, '.');
++	if (!first_dot)
++		return false;
++
++	const char* dns_portion = first_dot + 1;
++	const char* cluster_pos = strstr(dns_portion, CLUSTER_DASH_PREFIX);
++	if (!cluster_pos)
++		return false;
++
++	/* Pre-calculate all lengths */
++	const size_t db_name_len = first_dot - endpoint;
++	const size_t before_cluster_len = cluster_pos - dns_portion;
++	const size_t cluster_prefix_len = strlen(CLUSTER_DASH_PREFIX);
++	const size_t cluster_suffix_len = strlen(cluster_pos + cluster_prefix_len);
++	const size_t ro_prefix_len = strlen(CLUSTER_RO_PREFIX);
++	const size_t total_len = db_name_len + 1 + before_cluster_len + ro_prefix_len + cluster_suffix_len + 1;
++
++	if (total_len > endpoint_size)
++		return false;
++
++	char temp[MAX_ENDPOINT_LENGTH];
++	size_t pos = 0;
++
++	/* Build new string */
++	memcpy(temp, endpoint, db_name_len);
++	pos += db_name_len;
++	temp[pos++] = '.';
++	memcpy(temp + pos, dns_portion, before_cluster_len);
++	pos += before_cluster_len;
++	memcpy(temp + pos, CLUSTER_RO_PREFIX, ro_prefix_len);
++	pos += ro_prefix_len;
++	memcpy(temp + pos, cluster_pos + cluster_prefix_len, cluster_suffix_len);
++	pos += cluster_suffix_len;
++	temp[pos] = '\0';
++
++	/* Copy back to endpoint */
++	memcpy(endpoint, temp, total_len);
++	return true;
++}
++
++bool is_cluster_endpoint(char* endpoint) {
++	if (!endpoint)
++		return false;
++	/* Find the position of the first dot in the endpoint */
++	const char *dotPosition = strchr(endpoint, '.');
++
++	/* If no dot is found, it's not a valid format */
++	if (!dotPosition)
++		return false;
++
++	return (strncmp(dotPosition + 1, CLUSTER_PREFIX, strlen(CLUSTER_PREFIX)) == 0);
 +}

--- a/src/util.c.diff
+++ b/src/util.c.diff
@@ -1,10 +1,10 @@
 diff --git a/src/util.c b/src/util.c
-index 10bd2c3..6940c29 100644
+index fad0172..eaaadc0 100644
 --- a/src/util.c
 +++ b/src/util.c
-@@ -26,6 +26,33 @@
- #include <usual/crypto/csrandom.h>
- #include <usual/socket.h>
+@@ -32,6 +32,33 @@
+ #include <openssl/evp.h>
+ #endif
  
 +PgPool *get_global_writer(PgPool *pool)
 +{
@@ -36,3 +36,11 @@ index 10bd2c3..6940c29 100644
  int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstlen)
  {
  	const struct PgSocket *sock = ctx;
+@@ -532,3 +559,7 @@ bool check_reserved_database(const char *value)
+ 	}
+ 	return true;
+ }
++
++bool is_fast_switchover_disabled_for_pool(PgPool *pool) {
++	return !pool->db->topology_query || !fast_switchover;
++}

--- a/src/util.c.diff
+++ b/src/util.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/util.c b/src/util.c
-index fad0172..af5c802 100644
+index fad0172..d609ba6 100644
 --- a/src/util.c
 +++ b/src/util.c
 @@ -32,6 +32,33 @@
@@ -36,7 +36,7 @@ index fad0172..af5c802 100644
  int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstlen)
  {
  	const struct PgSocket *sock = ctx;
-@@ -532,3 +559,175 @@ bool check_reserved_database(const char *value)
+@@ -532,3 +559,221 @@ bool check_reserved_database(const char *value)
  	}
  	return true;
  }
@@ -212,3 +212,50 @@ index fad0172..af5c802 100644
 +
 +	return (strncmp(dotPosition + 1, CLUSTER_PREFIX, strlen(CLUSTER_PREFIX)) == 0);
 +}
++
++
++/**
++ * concat_multiple_strings - Concatenates multiple strings into a single dynamically allocated string.
++ *
++ * This function takes a variable number of string arguments and returns a new string
++ * that is the result of concatenating all non-NULL input strings in order. Memory for
++ * the result is dynamically allocated and must be freed by the caller. If memory
++ * allocation fails or count is 0 or negative, the function returns NULL.
++ *
++ * @param count The number of strings to concatenate.
++ * @param ...   The variable list of 'const char *' strings to concatenate.
++ *
++ * @return A pointer to the newly allocated concatenated string, or NULL on failure.
++ */
++char *concat_multiple_strings(int count, ...) {
++	if (count <= 0) return NULL;
++
++	va_list args;
++	size_t total_len = 1; // For null terminator
++
++	// First pass: calculate total length
++	va_start(args, count);
++	for (int i = 0; i < count; i++) {
++		const char *str = va_arg(args, const char *);
++		if (str) total_len += strlen(str);
++    }
++	va_end(args);
++
++	// Allocate memory
++	char *concat_str = malloc(total_len);
++	if (!concat_str) {
++		log_debug("malloc failed: no memory for concatenated string");
++		return NULL;
++	}
++
++	// Second pass: concatenate strings
++	concat_str[0] = '\0';
++	va_start(args, count);
++	for (int i = 0; i < count; i++) {
++		const char *str = va_arg(args, const char *);
++		if (str) strcat(concat_str, str);
++	}
++	va_end(args);
++	return concat_str;
++}
+\ No newline at end of file


### PR DESCRIPTION
Add fast switch over support for Blue Green Deployment
  * Introduce customer configurable topology_query. In order to get the
    endpoint of green node from metadata table.

  * Introduce customer configurable recovery_query. In order to get the
    BGD status during the switchover or when source connection dropped.

  * The topology_query run every time PgBouncer is started as well as reloaded
    to discover green node.

  * Once the topology_query runs, connection pools are created to the green node.

  * A switchover is discovered when the connection to the blue instance get
    killed. PgBouncer pauses the client and polls the green node with
    recovery_query to get the status of BGD. Once the BGD is in SWITCHOVER_IN_POST_PROCESSING
    which means green instance is writeable and then green node is cached for future connections.

  * A config option (polling_frequency) to determine how frequently to poll green node during
    a switchover has been added. Defaults to 100ms.
